### PR TITLE
feat: update app fonts with Inter and Cinzel

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -3,7 +3,13 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>Agent-First App</title>
+		<title>D&amp;D Character Manager</title>
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link
+			href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Inter:wght@400;500;600;700&display=swap"
+			rel="stylesheet"
+		/>
 	</head>
 	<body>
 		<div id="root"></div>

--- a/src/app/layout.module.css
+++ b/src/app/layout.module.css
@@ -2,7 +2,7 @@
 	min-height: 100vh;
 	background-color: var(--color-bg);
 	color: var(--color-text);
-	font-family: var(--font-family);
+	font-family: var(--font-body);
 	transition: background-color var(--transition-theme, 0.3s ease), color
 		var(--transition-theme, 0.3s ease);
 }

--- a/src/app/theme.css
+++ b/src/app/theme.css
@@ -100,8 +100,8 @@ a {
 	--space-xl: 2rem;
 
 	/* Typography */
-	--font-body: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-	--font-heading: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+	--font-body: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+	--font-heading: "Cinzel", Georgia, "Times New Roman", serif;
 	--font-mono: "Fira Code", "Cascadia Code", "Consolas", monospace;
 	--text-sm: 0.875rem;
 	--text-base: 1rem;


### PR DESCRIPTION
## Summary
- Added **Inter** (Google Fonts) as the body font — clean, modern, highly readable sans-serif
- Added **Cinzel** (Google Fonts) as the heading font — medieval/fantasy serif that fits the D&D theme
- Fixed broken `var(--font-family)` CSS variable reference in `layout.module.css` (should be `var(--font-body)`)
- Updated page title from "Agent-First App" to "D&D Character Manager"

## Changes
- `src/app/index.html` — added Google Fonts preconnect links and stylesheet import; updated `<title>`
- `src/app/theme.css` — updated `--font-body` and `--font-heading` CSS custom properties
- `src/app/layout.module.css` — fixed `var(--font-family)` → `var(--font-body)`

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes (336/336 tests)
- [ ] Verify Inter renders correctly for body text
- [ ] Verify Cinzel renders correctly for headings
- [ ] Verify system font fallbacks work when offline

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)