### PR TITLE
PERSISTENCE-44: harden production persistence and remember last opened character

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,29 @@ pnpm dev
 
 The app runs on **port 4000** by default.
 
+## Persistence Model
+
+- Character records live in SQLite only. The app does not store character sheets in cookies or `localStorage`.
+- The browser stores one lightweight value in `localStorage`: the last-opened character id used to restore the first visit back to `/`.
+- The server database path is resolved explicitly:
+  - `DATABASE_URL` unset: `<repo>/data/app.db`
+  - `DATABASE_URL` relative path: resolved from the repository/app root
+  - `DATABASE_URL` absolute path: used as-is
+
+## Production Runtime
+
+Production is intended to run from the main repository checkout, not from an ephemeral worktree.
+
+1. Start the app with Docker from the main checkout:
+   ```bash
+   docker compose up -d --build
+   ```
+2. Keep the SQLite file on the Docker volume mounted at `/app/data`.
+3. Publish the container through a Cloudflare Tunnel that forwards traffic to `http://localhost:4000`.
+
+The default production container configuration already points `DATABASE_URL` to `/app/data/app.db` and mounts persistent storage through Docker Compose.
+The server also logs the resolved SQLite path at startup, and `GET /api/debug/persistence` reports the active database file for verification.
+
 ## Scripts
 
 | Script          | Description                                      |

--- a/src/domains/character/ui/AbilityScoresGrid.tsx
+++ b/src/domains/character/ui/AbilityScoresGrid.tsx
@@ -15,12 +15,13 @@ export function AbilityScoresGrid({ character }: { character: Character }) {
 			<h2 className="text-base font-semibold text-foreground mb-2 border-b border-border pb-1">
 				Ability Scores
 			</h2>
-			<div className="grid grid-cols-3 gap-2 max-sm:grid-cols-2">
+			<div className="grid grid-cols-3 gap-2 max-sm:grid-cols-2" aria-label="Ability Scores">
 				{ABILITY_KEYS.map((key) => {
 					const mod = getAbilityModifier(character.abilityScores[key]);
 					return (
 						<div
 							key={key}
+							aria-label={`${key} ability score`}
 							className="text-center p-2 border border-border rounded-lg bg-muted transition-colors relative group"
 						>
 							<div className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity">

--- a/src/domains/character/ui/CharacterForm.tsx
+++ b/src/domains/character/ui/CharacterForm.tsx
@@ -5,10 +5,13 @@ import { Button } from "../../../app/components/ui/button.tsx";
 import { Input } from "../../../app/components/ui/input.tsx";
 import { Label } from "../../../app/components/ui/label.tsx";
 import { Skeleton } from "../../../app/components/ui/skeleton.tsx";
-import { useCurrentPath, useNavigate } from "../../../app/router.tsx";
+import { useNavigate } from "../../../app/router.tsx";
 import type { AbilityScores, Character } from "../types/index.js";
 import { AbilityScoresFieldset } from "./AbilityScoresFieldset.tsx";
-import { shouldAttemptInitialCharacterRestore } from "./last-opened-character.js";
+import {
+	hasAttemptedInitialCharacterRestore,
+	markInitialCharacterRestoreAttempted,
+} from "./last-opened-character.js";
 
 type CharacterFormValues = {
 	name: string;
@@ -32,7 +35,6 @@ interface CharacterFormProps {
 
 export function CharacterForm({ id }: CharacterFormProps) {
 	const navigate = useNavigate();
-	const currentPath = useCurrentPath();
 	const isEdit = id !== undefined && id !== "new";
 
 	const [loading, setLoading] = useState(isEdit);
@@ -48,8 +50,11 @@ export function CharacterForm({ id }: CharacterFormProps) {
 	});
 
 	useEffect(() => {
-		shouldAttemptInitialCharacterRestore(currentPath);
-	}, [currentPath]);
+		if (hasAttemptedInitialCharacterRestore()) {
+			return;
+		}
+		markInitialCharacterRestoreAttempted();
+	}, []);
 
 	useEffect(() => {
 		if (!isEdit) return;

--- a/src/domains/character/ui/CharacterForm.tsx
+++ b/src/domains/character/ui/CharacterForm.tsx
@@ -5,9 +5,10 @@ import { Button } from "../../../app/components/ui/button.tsx";
 import { Input } from "../../../app/components/ui/input.tsx";
 import { Label } from "../../../app/components/ui/label.tsx";
 import { Skeleton } from "../../../app/components/ui/skeleton.tsx";
-import { useNavigate } from "../../../app/router.tsx";
+import { useCurrentPath, useNavigate } from "../../../app/router.tsx";
 import type { AbilityScores, Character } from "../types/index.js";
 import { AbilityScoresFieldset } from "./AbilityScoresFieldset.tsx";
+import { shouldAttemptInitialCharacterRestore } from "./last-opened-character.js";
 
 type CharacterFormValues = {
 	name: string;
@@ -31,6 +32,7 @@ interface CharacterFormProps {
 
 export function CharacterForm({ id }: CharacterFormProps) {
 	const navigate = useNavigate();
+	const currentPath = useCurrentPath();
 	const isEdit = id !== undefined && id !== "new";
 
 	const [loading, setLoading] = useState(isEdit);
@@ -44,6 +46,10 @@ export function CharacterForm({ id }: CharacterFormProps) {
 		level: 1,
 		abilityScores: { STR: 10, DEX: 10, CON: 10, INT: 10, WIS: 10, CHA: 10 },
 	});
+
+	useEffect(() => {
+		shouldAttemptInitialCharacterRestore(currentPath);
+	}, [currentPath]);
 
 	useEffect(() => {
 		if (!isEdit) return;

--- a/src/domains/character/ui/CharacterList.tsx
+++ b/src/domains/character/ui/CharacterList.tsx
@@ -9,6 +9,7 @@ import type { Character } from "../types/index.js";
 import {
 	clearLastOpenedCharacterId,
 	getLastOpenedCharacterId,
+	markInitialCharacterRestoreAttempted,
 	rememberLastOpenedCharacterId,
 	shouldAttemptInitialCharacterRestore,
 } from "./last-opened-character.js";
@@ -23,7 +24,11 @@ export function CharacterList() {
 	const [loading, setLoading] = useState(true);
 
 	useEffect(() => {
+		let isMounted = true;
 		const shouldRestoreCharacter = shouldAttemptInitialCharacterRestore(currentPath);
+		if (shouldRestoreCharacter) {
+			markInitialCharacterRestoreAttempted();
+		}
 
 		fetch("/api/characters")
 			.then((r) => {
@@ -31,6 +36,10 @@ export function CharacterList() {
 				return r.json();
 			})
 			.then((data: Character[]) => {
+				if (!isMounted) {
+					return;
+				}
+
 				setCharacters(data);
 
 				const lastOpenedCharacterId = shouldRestoreCharacter ? getLastOpenedCharacterId() : null;
@@ -49,9 +58,19 @@ export function CharacterList() {
 				navigate(`/character/${lastOpenedCharacterId}`);
 			})
 			.catch(() => {
-				toast.error("Failed to load characters");
+				if (isMounted) {
+					toast.error("Failed to load characters");
+				}
 			})
-			.finally(() => setLoading(false));
+			.finally(() => {
+				if (isMounted) {
+					setLoading(false);
+				}
+			});
+
+		return () => {
+			isMounted = false;
+		};
 	}, [currentPath, navigate]);
 
 	return (

--- a/src/domains/character/ui/CharacterList.tsx
+++ b/src/domains/character/ui/CharacterList.tsx
@@ -4,30 +4,55 @@ import { toast } from "sonner";
 import { Badge } from "../../../app/components/ui/badge.tsx";
 import { Button } from "../../../app/components/ui/button.tsx";
 import { Skeleton } from "../../../app/components/ui/skeleton.tsx";
-import { useNavigate } from "../../../app/router.tsx";
+import { useCurrentPath, useNavigate } from "../../../app/router.tsx";
 import type { Character } from "../types/index.js";
-import { CharacterCard } from "./CharacterCard.tsx";
+import {
+	clearLastOpenedCharacterId,
+	getLastOpenedCharacterId,
+	rememberLastOpenedCharacterId,
+	shouldAttemptInitialCharacterRestore,
+} from "./last-opened-character.js";
 
 // Static skeleton keys to avoid array index lint warning
 const SKELETON_KEYS = ["sk1", "sk2", "sk3", "sk4", "sk5", "sk6"];
 
 export function CharacterList() {
 	const navigate = useNavigate();
+	const currentPath = useCurrentPath();
 	const [characters, setCharacters] = useState<Character[]>([]);
 	const [loading, setLoading] = useState(true);
 
 	useEffect(() => {
+		const shouldRestoreCharacter = shouldAttemptInitialCharacterRestore(currentPath);
+
 		fetch("/api/characters")
 			.then((r) => {
 				if (!r.ok) throw new Error("Server error");
 				return r.json();
 			})
-			.then((data) => setCharacters(data))
+			.then((data: Character[]) => {
+				setCharacters(data);
+
+				const lastOpenedCharacterId = shouldRestoreCharacter ? getLastOpenedCharacterId() : null;
+				if (!lastOpenedCharacterId) {
+					return;
+				}
+
+				const hasLastOpenedCharacter = data.some(
+					(character) => character.id === lastOpenedCharacterId,
+				);
+				if (!hasLastOpenedCharacter) {
+					clearLastOpenedCharacterId();
+					return;
+				}
+
+				navigate(`/character/${lastOpenedCharacterId}`);
+			})
 			.catch(() => {
 				toast.error("Failed to load characters");
 			})
 			.finally(() => setLoading(false));
-	}, []);
+	}, [currentPath, navigate]);
 
 	return (
 		<div className="max-w-[960px] mx-auto p-6 max-sm:p-3">
@@ -59,7 +84,10 @@ export function CharacterList() {
 							key={c.id}
 							type="button"
 							className="rounded-xl border border-border bg-card text-card-foreground shadow-sm transition-all p-6 cursor-pointer hover:border-primary hover:shadow-md text-left"
-							onClick={() => navigate(`/character/${c.id}`)}
+							onClick={() => {
+								rememberLastOpenedCharacterId(c.id);
+								navigate(`/character/${c.id}`);
+							}}
 						>
 							<div className="flex items-start justify-between gap-3 mb-1">
 								<div className="text-lg font-bold text-foreground">{c.name}</div>

--- a/src/domains/character/ui/CharacterSheet.tsx
+++ b/src/domains/character/ui/CharacterSheet.tsx
@@ -11,7 +11,7 @@ import {
 	TooltipTrigger,
 } from "../../../app/components/ui/tooltip.tsx";
 import { cn } from "../../../app/lib/utils.ts";
-import { useNavigate } from "../../../app/router.tsx";
+import { useCurrentPath, useNavigate } from "../../../app/router.tsx";
 import type { Character, LevelUpResult } from "../types/index.js";
 import { AbilityScoresGrid } from "./AbilityScoresGrid.tsx";
 import { ArmorClassSection } from "./ArmorClassSection.tsx";
@@ -25,6 +25,10 @@ import { SavingThrowsSection } from "./SavingThrowsSection.tsx";
 import { ShareSection } from "./ShareSection.tsx";
 import { SkillsSection } from "./SkillsSection.tsx";
 import { SpellSlotsSection } from "./SpellSlotsSection.tsx";
+import {
+	rememberLastOpenedCharacterId,
+	shouldAttemptInitialCharacterRestore,
+} from "./last-opened-character.js";
 
 async function postCharacterJson<T>(url: string, body?: unknown): Promise<T | null> {
 	const response = await fetch(url, {
@@ -37,6 +41,7 @@ async function postCharacterJson<T>(url: string, body?: unknown): Promise<T | nu
 
 export function CharacterSheet({ id, slug }: { id?: string; slug?: string }) {
 	const navigate = useNavigate();
+	const currentPath = useCurrentPath();
 	const [character, setCharacter] = useState<Character | null>(null);
 	const [loading, setLoading] = useState(true);
 	const [notes, setNotes] = useState("");
@@ -44,6 +49,10 @@ export function CharacterSheet({ id, slug }: { id?: string; slug?: string }) {
 	const [showLevelUpWizard, setShowLevelUpWizard] = useState(false);
 	const readOnly = !!slug;
 	const characterId = id ?? character?.id;
+
+	useEffect(() => {
+		shouldAttemptInitialCharacterRestore(currentPath);
+	}, [currentPath]);
 
 	useEffect(() => {
 		const url = slug ? `/api/characters/by-slug/${slug}` : `/api/characters/${id}`;
@@ -56,6 +65,12 @@ export function CharacterSheet({ id, slug }: { id?: string; slug?: string }) {
 			.catch(() => {})
 			.finally(() => setLoading(false));
 	}, [id, slug]);
+
+	useEffect(() => {
+		if (!readOnly && character?.id) {
+			rememberLastOpenedCharacterId(character.id);
+		}
+	}, [character?.id, readOnly]);
 
 	const handleDamage = () => {
 		const input = prompt("How much damage?");

--- a/src/domains/character/ui/CharacterSheet.tsx
+++ b/src/domains/character/ui/CharacterSheet.tsx
@@ -11,7 +11,7 @@ import {
 	TooltipTrigger,
 } from "../../../app/components/ui/tooltip.tsx";
 import { cn } from "../../../app/lib/utils.ts";
-import { useCurrentPath, useNavigate } from "../../../app/router.tsx";
+import { useNavigate } from "../../../app/router.tsx";
 import type { Character, LevelUpResult } from "../types/index.js";
 import { AbilityScoresGrid } from "./AbilityScoresGrid.tsx";
 import { ArmorClassSection } from "./ArmorClassSection.tsx";
@@ -26,8 +26,9 @@ import { ShareSection } from "./ShareSection.tsx";
 import { SkillsSection } from "./SkillsSection.tsx";
 import { SpellSlotsSection } from "./SpellSlotsSection.tsx";
 import {
+	hasAttemptedInitialCharacterRestore,
+	markInitialCharacterRestoreAttempted,
 	rememberLastOpenedCharacterId,
-	shouldAttemptInitialCharacterRestore,
 } from "./last-opened-character.js";
 
 async function postCharacterJson<T>(url: string, body?: unknown): Promise<T | null> {
@@ -41,7 +42,6 @@ async function postCharacterJson<T>(url: string, body?: unknown): Promise<T | nu
 
 export function CharacterSheet({ id, slug }: { id?: string; slug?: string }) {
 	const navigate = useNavigate();
-	const currentPath = useCurrentPath();
 	const [character, setCharacter] = useState<Character | null>(null);
 	const [loading, setLoading] = useState(true);
 	const [notes, setNotes] = useState("");
@@ -51,8 +51,11 @@ export function CharacterSheet({ id, slug }: { id?: string; slug?: string }) {
 	const characterId = id ?? character?.id;
 
 	useEffect(() => {
-		shouldAttemptInitialCharacterRestore(currentPath);
-	}, [currentPath]);
+		if (hasAttemptedInitialCharacterRestore()) {
+			return;
+		}
+		markInitialCharacterRestoreAttempted();
+	}, []);
 
 	useEffect(() => {
 		const url = slug ? `/api/characters/by-slug/${slug}` : `/api/characters/${id}`;

--- a/src/domains/character/ui/DeleteCharacterDialog.tsx
+++ b/src/domains/character/ui/DeleteCharacterDialog.tsx
@@ -9,6 +9,7 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "../../../app/components/ui/dialog.tsx";
+import { clearLastOpenedCharacterId, getLastOpenedCharacterId } from "./last-opened-character.js";
 
 interface DeleteCharacterDialogProps {
 	characterId: string;
@@ -36,6 +37,9 @@ export function DeleteCharacterDialog({
 			if (!res.ok) {
 				toast.error("Failed to delete character");
 				return;
+			}
+			if (getLastOpenedCharacterId() === characterId) {
+				clearLastOpenedCharacterId();
 			}
 			toast.success(`${characterName} has been deleted`);
 			onDeleted();

--- a/src/domains/character/ui/last-opened-character.test.ts
+++ b/src/domains/character/ui/last-opened-character.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	clearLastOpenedCharacterId,
+	getLastOpenedCharacterId,
+	rememberLastOpenedCharacterId,
+	resetLastOpenedCharacterMemoryForTests,
+	shouldAttemptInitialCharacterRestore,
+} from "./last-opened-character.js";
+
+const storage: Record<string, string> = {};
+
+const localStorageMock = {
+	getItem: vi.fn((key: string) => storage[key] ?? null),
+	setItem: vi.fn((key: string, value: string) => {
+		storage[key] = value;
+	}),
+	removeItem: vi.fn((key: string) => {
+		delete storage[key];
+	}),
+	clear: vi.fn(() => {
+		for (const key of Object.keys(storage)) {
+			delete storage[key];
+		}
+	}),
+};
+
+Object.defineProperty(globalThis, "localStorage", {
+	value: localStorageMock,
+	writable: true,
+});
+
+beforeEach(() => {
+	localStorageMock.clear();
+	resetLastOpenedCharacterMemoryForTests();
+	vi.clearAllMocks();
+});
+
+describe("last-opened-character", () => {
+	it("remembers and returns the last opened character id", () => {
+		rememberLastOpenedCharacterId("char-123");
+
+		expect(getLastOpenedCharacterId()).toBe("char-123");
+		expect(localStorageMock.setItem).toHaveBeenCalledWith("last-opened-character-id", "char-123");
+	});
+
+	it("clears the remembered character id", () => {
+		rememberLastOpenedCharacterId("char-123");
+
+		clearLastOpenedCharacterId();
+
+		expect(getLastOpenedCharacterId()).toBeNull();
+		expect(localStorageMock.removeItem).toHaveBeenCalledWith("last-opened-character-id");
+	});
+
+	it("only attempts the initial restore once when the app starts on root", () => {
+		expect(shouldAttemptInitialCharacterRestore("/")).toBe(true);
+		expect(shouldAttemptInitialCharacterRestore("/")).toBe(false);
+	});
+
+	it("does not redirect after an initial non-root load followed by a later visit home", () => {
+		expect(shouldAttemptInitialCharacterRestore("/character/abc")).toBe(false);
+		expect(shouldAttemptInitialCharacterRestore("/")).toBe(false);
+	});
+});

--- a/src/domains/character/ui/last-opened-character.test.ts
+++ b/src/domains/character/ui/last-opened-character.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	clearLastOpenedCharacterId,
 	getLastOpenedCharacterId,
+	markInitialCharacterRestoreAttempted,
 	rememberLastOpenedCharacterId,
 	resetLastOpenedCharacterMemoryForTests,
 	shouldAttemptInitialCharacterRestore,
@@ -54,11 +55,13 @@ describe("last-opened-character", () => {
 
 	it("only attempts the initial restore once when the app starts on root", () => {
 		expect(shouldAttemptInitialCharacterRestore("/")).toBe(true);
+		markInitialCharacterRestoreAttempted();
 		expect(shouldAttemptInitialCharacterRestore("/")).toBe(false);
 	});
 
 	it("does not redirect after an initial non-root load followed by a later visit home", () => {
 		expect(shouldAttemptInitialCharacterRestore("/character/abc")).toBe(false);
+		markInitialCharacterRestoreAttempted();
 		expect(shouldAttemptInitialCharacterRestore("/")).toBe(false);
 	});
 });

--- a/src/domains/character/ui/last-opened-character.ts
+++ b/src/domains/character/ui/last-opened-character.ts
@@ -1,0 +1,37 @@
+const LAST_OPENED_CHARACTER_STORAGE_KEY = "last-opened-character-id";
+
+let hasCheckedInitialCharacterRestore = false;
+
+function getStorage() {
+	if (typeof globalThis === "undefined" || !("localStorage" in globalThis)) {
+		return null;
+	}
+	return globalThis.localStorage;
+}
+
+export function rememberLastOpenedCharacterId(characterId: string) {
+	if (!characterId) {
+		return;
+	}
+	getStorage()?.setItem(LAST_OPENED_CHARACTER_STORAGE_KEY, characterId);
+}
+
+export function getLastOpenedCharacterId() {
+	return getStorage()?.getItem(LAST_OPENED_CHARACTER_STORAGE_KEY) ?? null;
+}
+
+export function clearLastOpenedCharacterId() {
+	getStorage()?.removeItem(LAST_OPENED_CHARACTER_STORAGE_KEY);
+}
+
+export function shouldAttemptInitialCharacterRestore(currentPath: string) {
+	if (hasCheckedInitialCharacterRestore) {
+		return false;
+	}
+	hasCheckedInitialCharacterRestore = true;
+	return currentPath === "/";
+}
+
+export function resetLastOpenedCharacterMemoryForTests() {
+	hasCheckedInitialCharacterRestore = false;
+}

--- a/src/domains/character/ui/last-opened-character.ts
+++ b/src/domains/character/ui/last-opened-character.ts
@@ -25,11 +25,15 @@ export function clearLastOpenedCharacterId() {
 }
 
 export function shouldAttemptInitialCharacterRestore(currentPath: string) {
-	if (hasCheckedInitialCharacterRestore) {
-		return false;
-	}
+	return !hasCheckedInitialCharacterRestore && currentPath === "/";
+}
+
+export function hasAttemptedInitialCharacterRestore() {
+	return hasCheckedInitialCharacterRestore;
+}
+
+export function markInitialCharacterRestoreAttempted() {
 	hasCheckedInitialCharacterRestore = true;
-	return currentPath === "/";
 }
 
 export function resetLastOpenedCharacterMemoryForTests() {

--- a/src/providers/db/connection.test.ts
+++ b/src/providers/db/connection.test.ts
@@ -32,6 +32,7 @@ describe("database connection", () => {
 
 	it("resolves the default database path from the repository root", () => {
 		const resolvedPath = resolveDbPath(undefined);
+		expect(existsSync(join(APP_ROOT, "package.json"))).toBe(true);
 		expect(resolvedPath).toBe(join(APP_ROOT, "data", "app.db"));
 		expect(isAbsolute(resolvedPath)).toBe(true);
 	});

--- a/src/providers/db/connection.test.ts
+++ b/src/providers/db/connection.test.ts
@@ -1,8 +1,8 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { createDb } from "./connection.js";
+import { APP_ROOT, createDb, resolveDbPath } from "./connection.js";
 import { migrate } from "./migrate.js";
 import { characters } from "./schema.js";
 
@@ -28,6 +28,31 @@ describe("database connection", () => {
 		const db = createDb(dbPath);
 		expect(db).toBeDefined();
 		expect(typeof db.select).toBe("function");
+	});
+
+	it("resolves the default database path from the repository root", () => {
+		const resolvedPath = resolveDbPath(undefined);
+		expect(resolvedPath).toBe(join(APP_ROOT, "data", "app.db"));
+		expect(isAbsolute(resolvedPath)).toBe(true);
+	});
+
+	it("resolves relative database paths from the repository root", () => {
+		expect(resolveDbPath("var/app.db")).toBe(join(APP_ROOT, "var", "app.db"));
+	});
+
+	it("preserves absolute database paths and sqlite memory paths", () => {
+		expect(resolveDbPath("/srv/app.db", "/tmp/project")).toBe("/srv/app.db");
+		expect(resolveDbPath(":memory:", "/tmp/project")).toBe(":memory:");
+	});
+
+	it("creates parent directories for nested database paths", () => {
+		const dir = mkdtempSync(join(tmpdir(), "db-test-"));
+		tempDirs.push(dir);
+		const dbPath = join(dir, "nested", "db", "app.db");
+
+		createDb(dbPath);
+
+		expect(existsSync(join(dir, "nested", "db"))).toBe(true);
 	});
 
 	it("can run migrations without error", () => {

--- a/src/providers/db/connection.ts
+++ b/src/providers/db/connection.ts
@@ -1,11 +1,26 @@
-import { mkdirSync } from "node:fs";
-import { dirname, isAbsolute, resolve } from "node:path";
+import { existsSync, mkdirSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import * as schema from "./schema.js";
 
 const SQLITE_MEMORY_PATH = ":memory:";
-const APP_ROOT = resolve(import.meta.dirname, "../../..");
+
+function findAppRoot(startDir: string) {
+	let currentDir = resolve(startDir);
+
+	while (!existsSync(join(currentDir, "package.json"))) {
+		const parentDir = dirname(currentDir);
+		if (parentDir === currentDir) {
+			throw new Error(`Could not find package.json from ${startDir}`);
+		}
+		currentDir = parentDir;
+	}
+
+	return currentDir;
+}
+
+const APP_ROOT = findAppRoot(import.meta.dirname);
 
 export function resolveDbPath(
 	databaseUrl: string | undefined = process.env.DATABASE_URL,

--- a/src/providers/db/connection.ts
+++ b/src/providers/db/connection.ts
@@ -1,18 +1,37 @@
 import { mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, isAbsolute, resolve } from "node:path";
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import * as schema from "./schema.js";
 
-const DB_PATH = process.env.DATABASE_URL ?? join(process.cwd(), "data", "app.db");
+const SQLITE_MEMORY_PATH = ":memory:";
+const APP_ROOT = resolve(import.meta.dirname, "../../..");
+
+export function resolveDbPath(
+	databaseUrl: string | undefined = process.env.DATABASE_URL,
+	baseDir: string = APP_ROOT,
+) {
+	if (!databaseUrl) {
+		return resolve(baseDir, "data", "app.db");
+	}
+	if (databaseUrl === SQLITE_MEMORY_PATH || isAbsolute(databaseUrl)) {
+		return databaseUrl;
+	}
+	return resolve(baseDir, databaseUrl);
+}
+
+const DB_PATH = resolveDbPath();
 
 /**
  * Create a database connection with better-sqlite3 and drizzle.
  * Ensures the data/ directory exists.
  */
 export function createDb(dbPath: string = DB_PATH) {
-	mkdirSync(join(dbPath, ".."), { recursive: true });
-	const sqlite = new Database(dbPath);
+	const resolvedDbPath = resolveDbPath(dbPath);
+	if (resolvedDbPath !== SQLITE_MEMORY_PATH) {
+		mkdirSync(dirname(resolvedDbPath), { recursive: true });
+	}
+	const sqlite = new Database(resolvedDbPath);
 	sqlite.pragma("journal_mode = WAL");
 	return drizzle(sqlite, { schema });
 }
@@ -32,5 +51,5 @@ export function _setDb(db: ReturnType<typeof createDb>) {
 	_db = db;
 }
 
-export { DB_PATH };
+export { APP_ROOT, DB_PATH };
 export type AppDatabase = ReturnType<typeof createDb>;

--- a/src/providers/db/index.ts
+++ b/src/providers/db/index.ts
@@ -1,3 +1,3 @@
 export { characters, type Character, type NewCharacter } from "./schema.js";
-export { createDb, getDb, _setDb, type AppDatabase } from "./connection.js";
+export { APP_ROOT, DB_PATH, createDb, getDb, _setDb, type AppDatabase } from "./connection.js";
 export { migrate } from "./migrate.js";

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -6,6 +6,10 @@ describe("server health check", () => {
 
 	beforeAll(async () => {
 		app.get("/health", async () => ({ status: "ok" }));
+		app.get("/api/debug/persistence", async () => ({
+			databasePath: "/app/data/app.db",
+			nodeEnv: "test",
+		}));
 		await app.ready();
 	});
 
@@ -17,5 +21,14 @@ describe("server health check", () => {
 		const res = await app.inject({ method: "GET", url: "/health" });
 		expect(res.statusCode).toBe(200);
 		expect(res.json()).toEqual({ status: "ok" });
+	});
+
+	it("GET /api/debug/persistence returns the resolved database path", async () => {
+		const res = await app.inject({ method: "GET", url: "/api/debug/persistence" });
+		expect(res.statusCode).toBe(200);
+		expect(res.json()).toEqual({
+			databasePath: "/app/data/app.db",
+			nodeEnv: "test",
+		});
 	});
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,7 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import fastifyStatic from "@fastify/static";
-import { getDb, migrate } from "@providers/db/index.js";
+import { DB_PATH, getDb, migrate } from "@providers/db/index.js";
 import { createLogger } from "@providers/telemetry/index.js";
 import Fastify from "fastify";
 import { registerCharacterRoutes } from "./domains/character/runtime/routes.js";
@@ -17,14 +17,19 @@ import { registerItemRoutes } from "./domains/example/runtime/routes.js";
 const log = createLogger("server");
 
 // Initialize database and run migrations before starting
+log.info({ dbPath: DB_PATH }, "Using SQLite database");
 const db = getDb();
 migrate(db);
-log.info("Database migrations applied");
+log.info({ dbPath: DB_PATH }, "Database migrations applied");
 
 const app = Fastify({ logger: false });
 
 // Health check endpoint
 app.get("/health", async () => ({ status: "ok" }));
+app.get("/api/debug/persistence", async () => ({
+	databasePath: DB_PATH,
+	nodeEnv: process.env.NODE_ENV ?? "development",
+}));
 
 // Register domain routes
 await registerItemRoutes(app);

--- a/tests/e2e/character-delete.spec.ts
+++ b/tests/e2e/character-delete.spec.ts
@@ -12,7 +12,7 @@ test.describe("Character deletion", () => {
 		await page.getByRole("button", { name: "Delete" }).click();
 
 		await expect(page.getByRole("heading", { name: "Characters" })).toBeVisible();
-		await expect(page.getByText("Thorin Ironforge")).not.toBeVisible();
+		await expect(page.getByRole("button", { name: "Thorin Ironforge" })).not.toBeVisible();
 		await expect(page.getByText("No characters yet. Create your first adventurer!")).toBeVisible();
 	});
 });

--- a/tests/e2e/character-sheet.spec.ts
+++ b/tests/e2e/character-sheet.spec.ts
@@ -9,12 +9,11 @@ test.describe("Character sheet view", () => {
 		await expect(page.getByText("Dwarf Fighter · Level 5")).toBeVisible();
 
 		await expect(page.getByText("Ability Scores")).toBeVisible();
-		const abilitySection = page.locator("div").filter({ hasText: "Ability Scores" }).first();
 		for (const stat of ["STR", "DEX", "CON", "INT", "WIS", "CHA"]) {
-			await expect(abilitySection.locator("div").filter({ hasText: new RegExp(`^${stat}$`) })).toBeVisible();
+			await expect(page.getByLabel(`${stat} ability score`)).toContainText(stat);
 		}
 
-		await expect(page.getByText("Hit Points")).toBeVisible();
+		await expect(page.getByRole("heading", { name: "Hit Points" })).toBeVisible();
 		await expect(page.getByText("10 / 10")).toBeVisible();
 		await expect(page.getByRole("heading", { name: "Conditions" })).toBeVisible();
 
@@ -45,9 +44,8 @@ test.describe("Character sheet view", () => {
 		await page.goto("/");
 		await page.getByText("Thorin Ironforge").click();
 
-		const abilitySection = page.locator("div").filter({ hasText: "Ability Scores" }).first();
-		await expect(abilitySection.locator("div").filter({ hasText: /^\+3$/ })).toBeVisible();
-		await expect(abilitySection.locator("div").filter({ hasText: /^-1$/ })).toBeVisible();
+		await expect(page.getByLabel("STR ability score")).toContainText("+3");
+		await expect(page.getByLabel("CHA ability score")).toContainText("-1");
 	});
 
 	test("tracks temp HP, concentration, and active conditions", async ({ page, createCharacter }) => {
@@ -59,7 +57,7 @@ test.describe("Character sheet view", () => {
 		await page.goto(`/character/${character.id}`);
 
 		await expect(page.getByText("18 / 24")).toBeVisible();
-		await expect(page.getByText("+7 temp")).toBeVisible();
+		await expect(page.getByText("+7 temp", { exact: true })).toBeVisible();
 		await expect(page.getByText("Concentration").first()).toBeVisible();
 		await expect(page.getByLabel("Active conditions indicator")).toContainText("1 active");
 		await expect(page.getByLabel("Active conditions list")).toContainText("Poisoned (4r)");

--- a/tests/e2e/responsive.spec.ts
+++ b/tests/e2e/responsive.spec.ts
@@ -35,7 +35,7 @@ test.describe("Responsive layout", () => {
 
 		await expect(page.getByRole("heading", { name: "Thorin Ironforge" })).toBeVisible();
 		await expect(page.getByText("Ability Scores")).toBeVisible();
-		await expect(page.getByText("Hit Points")).toBeVisible();
+		await expect(page.getByRole("heading", { name: "Hit Points" })).toBeVisible();
 		await expect(page.getByText("Skills")).toBeVisible();
 
 		// All content should be within viewport width
@@ -50,6 +50,6 @@ test.describe("Responsive layout", () => {
 
 		await expect(page.getByRole("heading", { name: "Thorin Ironforge" })).toBeVisible();
 		await expect(page.getByText("Ability Scores")).toBeVisible();
-		await expect(page.getByText("Hit Points")).toBeVisible();
+		await expect(page.getByRole("heading", { name: "Hit Points" })).toBeVisible();
 	});
 });


### PR DESCRIPTION
## Summary
- harden SQLite path resolution so production uses a stable database file independent of launch cwd
- add startup/debug visibility for the active database path and document the Docker-backed persistence runtime
- remember the last opened character in localStorage with safe fallback when that character no longer exists

## Validation
- pnpm lint
- pnpm test

## Links
- Linear issue: https://github.com/linuxlewis/dnd-character-manager/issues/44