### PR TITLE
feat(ui): character sheet layout overhaul with combat vitals bar

### DIFF
--- a/src/domains/character/ui/CharacterSheet.test.ts
+++ b/src/domains/character/ui/CharacterSheet.test.ts
@@ -268,4 +268,12 @@ describe("CharacterSheet uses shadcn/ui and Tailwind", () => {
 		expect(hpSource).toContain('variant="destructive-ghost"');
 		expect(hpSource).toContain('variant="success-ghost"');
 	});
+
+	it("uses shadcn/ui Tabs for tabbed layout", () => {
+		expect(source).toContain('from "../../../app/components/ui/tabs.tsx"');
+	});
+
+	it("imports CombatVitalsBar for at-a-glance combat info", () => {
+		expect(source).toContain('from "./CombatVitalsBar.tsx"');
+	});
 });

--- a/src/domains/character/ui/CharacterSheet.tsx
+++ b/src/domains/character/ui/CharacterSheet.tsx
@@ -1,20 +1,14 @@
-import { ArrowLeft, ShieldAlert, TrendingUp } from "lucide-react";
+import { ArrowLeft, TrendingUp } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { Badge } from "../../../app/components/ui/badge.tsx";
 import { Button } from "../../../app/components/ui/button.tsx";
-
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipProvider,
-	TooltipTrigger,
-} from "../../../app/components/ui/tooltip.tsx";
-import { cn } from "../../../app/lib/utils.ts";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../../app/components/ui/tabs.tsx";
+import { TooltipProvider } from "../../../app/components/ui/tooltip.tsx";
 import { useNavigate } from "../../../app/router.tsx";
 import type { Character, LevelUpResult } from "../types/index.js";
 import { AbilityScoresGrid } from "./AbilityScoresGrid.tsx";
 import { ArmorClassSection } from "./ArmorClassSection.tsx";
+import { CombatVitalsBar } from "./CombatVitalsBar.tsx";
 import { ConditionsSection } from "./ConditionsSection.tsx";
 import { DeleteCharacterDialog } from "./DeleteCharacterDialog.tsx";
 import { EquipmentSection } from "./EquipmentSection.tsx";
@@ -171,10 +165,10 @@ export function CharacterSheet({ id, slug }: { id?: string; slug?: string }) {
 					<ArrowLeft className="h-4 w-4" />
 					Back
 				</Button>
-				<div className="flex items-start justify-between gap-4 mb-1">
+				<div className="flex items-start justify-between gap-4 mb-2">
 					<div className="flex-1">
 						<h1 className="text-2xl text-foreground">{character.name}</h1>
-						<div className="flex items-center gap-3 mb-4">
+						<div className="flex items-center gap-3 mb-2">
 							<p className="text-muted-foreground">
 								{character.race} {character.class} · Level {character.level}
 							</p>
@@ -191,70 +185,81 @@ export function CharacterSheet({ id, slug }: { id?: string; slug?: string }) {
 							)}
 						</div>
 					</div>
-					{character.conditions.length > 0 && (
-						<Badge variant="destructive" className="gap-1" aria-label="Active conditions indicator">
-							<ShieldAlert className="h-3.5 w-3.5" />
-							{character.conditions.length} active
-						</Badge>
-					)}
 				</div>
 				{character.slug && !readOnly && <ShareSection slug={character.slug} />}
-				<AbilityScoresGrid character={character} />
-				<HitPointsSection
-					character={character}
-					hpPercent={hpPercent}
-					readOnly={readOnly}
-					onDamage={handleDamage}
-					onHeal={handleHeal}
-					onUpdate={setCharacter}
-				/>
-				<ConditionsSection character={character} readOnly={readOnly} onUpdate={setCharacter} />
-				{!readOnly && characterId && (
-					<>
-						<ArmorClassSection
+				<CombatVitalsBar character={character} />
+				<Tabs defaultValue="combat">
+					<TabsList>
+						<TabsTrigger value="combat">Combat</TabsTrigger>
+						<TabsTrigger value="stats">Stats</TabsTrigger>
+						<TabsTrigger value="gear">Gear</TabsTrigger>
+						<TabsTrigger value="notes">Notes</TabsTrigger>
+					</TabsList>
+					<TabsContent value="combat">
+						<HitPointsSection
 							character={character}
-							characterId={characterId}
+							hpPercent={hpPercent}
+							readOnly={readOnly}
+							onDamage={handleDamage}
+							onHeal={handleHeal}
 							onUpdate={setCharacter}
 						/>
-						<SavingThrowsSection
-							character={character}
-							characterId={characterId}
-							onUpdate={setCharacter}
+						{!readOnly && characterId && (
+							<ArmorClassSection
+								character={character}
+								characterId={characterId}
+								onUpdate={setCharacter}
+							/>
+						)}
+						<ConditionsSection character={character} readOnly={readOnly} onUpdate={setCharacter} />
+						{characterId && (
+							<SpellSlotsSection
+								character={character}
+								characterId={characterId}
+								onUpdate={setCharacter}
+							/>
+						)}
+					</TabsContent>
+					<TabsContent value="stats">
+						<AbilityScoresGrid character={character} />
+						{!readOnly && characterId && (
+							<SavingThrowsSection
+								character={character}
+								characterId={characterId}
+								onUpdate={setCharacter}
+							/>
+						)}
+						{characterId && (
+							<SkillsSection
+								character={character}
+								characterId={characterId}
+								readOnly={readOnly}
+								onUpdate={setCharacter}
+							/>
+						)}
+					</TabsContent>
+					<TabsContent value="gear">
+						{characterId && (
+							<EquipmentSection
+								characterId={characterId}
+								equipment={character.equipment ?? []}
+								strScore={character.abilityScores.STR}
+								readOnly={readOnly}
+								onUpdate={setCharacter}
+							/>
+						)}
+					</TabsContent>
+					<TabsContent value="notes">
+						<NotesSection
+							notes={notes}
+							readOnly={readOnly}
+							onChange={setNotes}
+							onBlur={handleNotesBlur}
 						/>
-					</>
-				)}
-				{characterId && (
-					<SkillsSection
-						character={character}
-						characterId={characterId}
-						readOnly={readOnly}
-						onUpdate={setCharacter}
-					/>
-				)}
-				{characterId && (
-					<SpellSlotsSection
-						character={character}
-						characterId={characterId}
-						onUpdate={setCharacter}
-					/>
-				)}
-				{characterId && (
-					<EquipmentSection
-						characterId={characterId}
-						equipment={character.equipment ?? []}
-						strScore={character.abilityScores.STR}
-						readOnly={readOnly}
-						onUpdate={setCharacter}
-					/>
-				)}
-				<NotesSection
-					notes={notes}
-					readOnly={readOnly}
-					onChange={setNotes}
-					onBlur={handleNotesBlur}
-				/>
+					</TabsContent>
+				</Tabs>
 				{!readOnly && (
-					<div className="mb-6">
+					<div className="mb-6 mt-6">
 						<Button variant="destructive" className="w-full" onClick={handleDeleteClick}>
 							Delete Character
 						</Button>

--- a/src/domains/character/ui/CombatVitalsBar.test.ts
+++ b/src/domains/character/ui/CombatVitalsBar.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { calculateAC, getAbilityModifier } from "../types/character.js";
+
+describe("CombatVitalsBar", () => {
+	it("exports CombatVitalsBar component", async () => {
+		const mod = await import("./CombatVitalsBar.tsx");
+		expect(typeof mod.CombatVitalsBar).toBe("function");
+	});
+
+	it("uses HP color thresholds consistent with HitPointsSection", () => {
+		const vitalsSource = readFileSync(resolve(__dirname, "CombatVitalsBar.tsx"), "utf-8");
+		expect(vitalsSource).toContain("bg-success");
+		expect(vitalsSource).toContain("bg-warning");
+		expect(vitalsSource).toContain("bg-destructive");
+	});
+
+	it("displays AC using calculateAC", () => {
+		const vitalsSource = readFileSync(resolve(__dirname, "CombatVitalsBar.tsx"), "utf-8");
+		expect(vitalsSource).toContain("calculateAC");
+	});
+
+	it("shows initiative modifier from DEX", () => {
+		const vitalsSource = readFileSync(resolve(__dirname, "CombatVitalsBar.tsx"), "utf-8");
+		expect(vitalsSource).toContain("getAbilityModifier");
+		expect(vitalsSource).toContain("abilityScores.DEX");
+	});
+
+	it("shows active conditions count", () => {
+		const vitalsSource = readFileSync(resolve(__dirname, "CombatVitalsBar.tsx"), "utf-8");
+		expect(vitalsSource).toContain("activeConditions.length");
+	});
+
+	it("calculates AC with DEX modifier", () => {
+		expect(calculateAC(14, { base: 10, override: null })).toBe(12);
+	});
+
+	it("uses AC override when set", () => {
+		expect(calculateAC(14, { base: 10, override: 16 })).toBe(16);
+	});
+
+	it("calculates initiative modifier from DEX score", () => {
+		expect(getAbilityModifier(14)).toBe(2);
+		expect(getAbilityModifier(10)).toBe(0);
+		expect(getAbilityModifier(8)).toBe(-1);
+	});
+});

--- a/src/domains/character/ui/CombatVitalsBar.tsx
+++ b/src/domains/character/ui/CombatVitalsBar.tsx
@@ -1,0 +1,81 @@
+import { AlertTriangle, Shield } from "lucide-react";
+import { Badge } from "../../../app/components/ui/badge.tsx";
+import { cn } from "../../../app/lib/utils.ts";
+import { calculateAC, getAbilityModifier } from "../types/character.js";
+import type { Character } from "../types/index.js";
+
+interface CombatVitalsBarProps {
+	character: Character;
+}
+
+export function CombatVitalsBar({ character }: CombatVitalsBarProps) {
+	const acValue = calculateAC(character.abilityScores.DEX, character.armorClass);
+	const hpPercent = character.hp.max > 0 ? (character.hp.current / character.hp.max) * 100 : 0;
+	const activeConditions = character.conditions;
+	const initiativeMod = getAbilityModifier(character.abilityScores.DEX);
+	const formattedInit = initiativeMod >= 0 ? `+${initiativeMod}` : `${initiativeMod}`;
+
+	return (
+		<div
+			className="grid grid-cols-[auto_1fr_auto] gap-3 items-center p-3 bg-muted/50 border border-border rounded-lg mb-4"
+			aria-label="Combat vitals"
+		>
+			<div className="flex items-center gap-3">
+				<div className="flex flex-col items-center justify-center w-14 h-16 border-2 border-steel rounded-b-[50%] bg-card shadow-sm">
+					<span
+						className="text-xl font-heading font-bold text-foreground leading-none"
+						data-testid="vitals-ac-value"
+					>
+						{acValue}
+					</span>
+					<span className="text-[0.55rem] text-muted-foreground uppercase font-semibold tracking-wider">
+						AC
+					</span>
+				</div>
+				<div className="text-center px-2">
+					<span className="text-lg font-mono font-bold text-foreground">{formattedInit}</span>
+					<div className="text-[0.55rem] text-muted-foreground uppercase font-semibold tracking-wider">
+						Init
+					</div>
+				</div>
+			</div>
+
+			<div className="min-w-0">
+				<div className="flex items-center gap-2 mb-1">
+					<span className="text-sm font-bold text-foreground">
+						{character.hp.current}/{character.hp.max}
+					</span>
+					<span className="text-xs text-muted-foreground">HP</span>
+					{character.hp.temp > 0 && (
+						<Badge variant="success" className="text-[10px] px-1.5 py-0">
+							+{character.hp.temp}
+						</Badge>
+					)}
+					{character.concentration && (
+						<Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+							Conc
+						</Badge>
+					)}
+				</div>
+				<div className="w-full h-2.5 bg-muted border border-border rounded-full overflow-hidden">
+					<div
+						className={cn(
+							"h-full rounded-full transition-all duration-300",
+							hpPercent > 50 ? "bg-success" : hpPercent > 25 ? "bg-warning" : "bg-destructive",
+						)}
+						style={{ width: `${hpPercent}%` }}
+					/>
+				</div>
+			</div>
+
+			{activeConditions.length > 0 && (
+				<div className="flex items-center">
+					<Badge variant="destructive" className="gap-1 whitespace-nowrap">
+						<AlertTriangle className="h-3 w-3" />
+						{activeConditions.length}
+					</Badge>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/tests/e2e/character-edit.spec.ts
+++ b/tests/e2e/character-edit.spec.ts
@@ -25,13 +25,15 @@ test.describe("Edit character", () => {
 
 		// Navigate to character sheet to verify changes
 		await page.getByText("Thorin Ironforge").click();
-		await expect(page.getByText("20")).toBeVisible(); // New STR
-		await expect(page.getByText("15")).toBeVisible(); // New CHA
+		await page.getByRole("tab", { name: "Stats" }).click();
+		await expect(page.getByLabel("STR ability score")).toContainText("20");
+		await expect(page.getByLabel("CHA ability score")).toContainText("15");
 
 		// Refresh and verify persistence
 		await page.reload();
-		await expect(page.getByText("20")).toBeVisible();
-		await expect(page.getByText("15")).toBeVisible();
+		await page.getByRole("tab", { name: "Stats" }).click();
+		await expect(page.getByLabel("STR ability score")).toContainText("20");
+		await expect(page.getByLabel("CHA ability score")).toContainText("15");
 	});
 
 	test("edit form loads existing character data", async ({ page, createCharacter }) => {

--- a/tests/e2e/character-sheet.spec.ts
+++ b/tests/e2e/character-sheet.spec.ts
@@ -7,24 +7,31 @@ test.describe("Character sheet view", () => {
 
 		await expect(page.getByRole("heading", { name: "Thorin Ironforge" })).toBeVisible();
 		await expect(page.getByText("Dwarf Fighter · Level 5")).toBeVisible();
-
-		await expect(page.getByText("Ability Scores")).toBeVisible();
-		for (const stat of ["STR", "DEX", "CON", "INT", "WIS", "CHA"]) {
-			await expect(page.getByLabel(`${stat} ability score`)).toContainText(stat);
-		}
+		await expect(page.getByLabel("Combat vitals")).toBeVisible();
+		await expect(page.getByRole("tab", { name: "Combat" })).toHaveAttribute("aria-selected", "true");
 
 		await expect(page.getByRole("heading", { name: "Hit Points" })).toBeVisible();
 		await expect(page.getByText("10 / 10")).toBeVisible();
 		await expect(page.getByRole("heading", { name: "Conditions" })).toBeVisible();
+		await expect(page.getByRole("button", { name: "Damage" })).toBeVisible();
+		await expect(page.getByRole("button", { name: "Heal" })).toBeVisible();
 
+		await page.getByRole("tab", { name: "Stats" }).click();
+		await expect(page.getByText("Ability Scores")).toBeVisible();
+		for (const stat of ["STR", "DEX", "CON", "INT", "WIS", "CHA"]) {
+			await expect(page.getByLabel(`${stat} ability score`)).toContainText(stat);
+		}
 		await expect(page.getByText("Skills")).toBeVisible();
 		await expect(page.getByText("Athletics")).toBeVisible();
 		await expect(page.getByText("Perception")).toBeVisible();
 
-		await expect(page.getByRole("heading", { name: "Notes" })).toBeVisible();
+		await page.getByRole("tab", { name: "Gear" }).click();
+		await expect(page.getByRole("heading", { name: "Equipment" })).toBeVisible();
 
-		await expect(page.getByRole("button", { name: "Damage" })).toBeVisible();
-		await expect(page.getByRole("button", { name: "Heal" })).toBeVisible();
+		await page.getByRole("tab", { name: "Notes" }).click();
+		await expect(page.getByRole("heading", { name: "Notes" })).toBeVisible();
+		await expect(page.getByRole("textbox", { name: "Character notes" })).toBeVisible();
+
 		await expect(page.getByRole("button", { name: "Delete Character" })).toBeVisible();
 	});
 
@@ -43,6 +50,7 @@ test.describe("Character sheet view", () => {
 		await createCharacter();
 		await page.goto("/");
 		await page.getByText("Thorin Ironforge").click();
+		await page.getByRole("tab", { name: "Stats" }).click();
 
 		await expect(page.getByLabel("STR ability score")).toContainText("+3");
 		await expect(page.getByLabel("CHA ability score")).toContainText("-1");
@@ -56,10 +64,11 @@ test.describe("Character sheet view", () => {
 		});
 		await page.goto(`/character/${character.id}`);
 
-		await expect(page.getByText("18 / 24")).toBeVisible();
-		await expect(page.getByText("+7 temp", { exact: true })).toBeVisible();
-		await expect(page.getByText("Concentration").first()).toBeVisible();
-		await expect(page.getByLabel("Active conditions indicator")).toContainText("1 active");
+		const combatVitals = page.getByLabel("Combat vitals");
+		await expect(combatVitals).toContainText("18/24");
+		await expect(combatVitals).toContainText("+7");
+		await expect(combatVitals).toContainText("Conc");
+		await expect(combatVitals).toContainText("1");
 		await expect(page.getByLabel("Active conditions list")).toContainText("Poisoned (4r)");
 	});
 

--- a/tests/e2e/equipment.spec.ts
+++ b/tests/e2e/equipment.spec.ts
@@ -1,9 +1,14 @@
 import { expect, test } from "./fixtures.ts";
 
 test.describe("Equipment management", () => {
+	test.beforeEach(async ({ page }) => {
+		page.on("dialog", (dialog) => dialog.dismiss());
+	});
+
 	test("adds and removes an equipment item", async ({ page, createCharacter }) => {
 		const character = await createCharacter();
 		await page.goto(`/character/${character.id}`);
+		await page.getByRole("tab", { name: "Gear" }).click();
 
 		await page.getByLabel("Item name").fill("Longsword");
 		await page.getByLabel("Quantity").fill("1");
@@ -20,6 +25,7 @@ test.describe("Equipment management", () => {
 	test("adds equipment with category and description", async ({ page, createCharacter }) => {
 		const character = await createCharacter();
 		await page.goto(`/character/${character.id}`);
+		await page.getByRole("tab", { name: "Gear" }).click();
 
 		await page.getByLabel("Item name").fill("Chain Mail");
 		await page.getByLabel("Category").selectOption("armor");
@@ -37,6 +43,7 @@ test.describe("Equipment management", () => {
 	test("equips and unequips an item", async ({ page, createCharacter }) => {
 		const character = await createCharacter();
 		await page.goto(`/character/${character.id}`);
+		await page.getByRole("tab", { name: "Gear" }).click();
 
 		await page.getByLabel("Item name").fill("Longsword");
 		await page.getByLabel("Category").selectOption("weapon");
@@ -48,8 +55,6 @@ test.describe("Equipment management", () => {
 
 		await page.getByRole("button", { name: "Equip Longsword" }).click();
 		await expect(page.getByRole("button", { name: "Unequip Longsword" })).toBeVisible();
-
-		// Equipped items section should show the item
 		await expect(page.getByText("Equipped").first()).toBeVisible();
 
 		await page.getByRole("button", { name: "Unequip Longsword" }).click();
@@ -57,15 +62,14 @@ test.describe("Equipment management", () => {
 	});
 
 	test("displays carrying capacity based on STR", async ({ page, createCharacter }) => {
-		// STR 16 = 240 lbs capacity
 		const character = await createCharacter({
 			abilityScores: { STR: 16, DEX: 12, CON: 14, INT: 10, WIS: 13, CHA: 8 },
 		});
 		await page.goto(`/character/${character.id}`);
+		await page.getByRole("tab", { name: "Gear" }).click();
 
 		await expect(page.getByText("Weight: 0 / 240 lbs")).toBeVisible();
 
-		// Add heavy item
 		await page.getByLabel("Item name").fill("Heavy Plate");
 		await page.getByLabel("Quantity").fill("1");
 		await page.getByLabel("Weight").fill("65");
@@ -75,13 +79,12 @@ test.describe("Equipment management", () => {
 	});
 
 	test("shows encumbered warning when over capacity", async ({ page, createCharacter }) => {
-		// STR 8 = 120 lbs capacity
 		const character = await createCharacter({
 			abilityScores: { STR: 8, DEX: 12, CON: 14, INT: 10, WIS: 13, CHA: 8 },
 		});
 		await page.goto(`/character/${character.id}`);
+		await page.getByRole("tab", { name: "Gear" }).click();
 
-		// Add item heavier than capacity
 		await page.getByLabel("Item name").fill("Giant Rock");
 		await page.getByLabel("Quantity").fill("1");
 		await page.getByLabel("Weight").fill("150");
@@ -94,8 +97,8 @@ test.describe("Equipment management", () => {
 	test("manages multiple items with different categories", async ({ page, createCharacter }) => {
 		const character = await createCharacter();
 		await page.goto(`/character/${character.id}`);
+		await page.getByRole("tab", { name: "Gear" }).click();
 
-		// Add weapon
 		await page.getByLabel("Item name").fill("Longsword");
 		await page.getByLabel("Category").selectOption("weapon");
 		await page.getByLabel("Quantity").fill("1");
@@ -103,7 +106,6 @@ test.describe("Equipment management", () => {
 		await page.getByRole("button", { name: "Add" }).click();
 		await expect(page.getByText("Longsword").first()).toBeVisible();
 
-		// Add armor
 		await page.getByLabel("Item name").fill("Shield");
 		await page.getByLabel("Category").selectOption("shield");
 		await page.getByLabel("Quantity").fill("1");
@@ -111,7 +113,6 @@ test.describe("Equipment management", () => {
 		await page.getByRole("button", { name: "Add" }).click();
 		await expect(page.getByText("Shield").first()).toBeVisible();
 
-		// Add potions
 		await page.getByLabel("Item name").fill("Healing Potion");
 		await page.getByLabel("Category").selectOption("potion");
 		await page.getByLabel("Quantity").fill("3");
@@ -119,7 +120,6 @@ test.describe("Equipment management", () => {
 		await page.getByRole("button", { name: "Add" }).click();
 		await expect(page.getByText("Healing Potion").first()).toBeVisible();
 
-		// Total weight: 3 + 6 + (0.5*3) = 10.5
 		await expect(page.getByText("Weight: 10.5 / 240 lbs")).toBeVisible();
 	});
 
@@ -127,7 +127,6 @@ test.describe("Equipment management", () => {
 		const character = await createCharacter();
 		await page.goto(`/characters/${character.slug}`);
 
-		// The add form should not be visible on read-only view
 		await expect(page.getByLabel("Item name")).not.toBeVisible();
 		await expect(page.getByRole("button", { name: "Add" })).not.toBeVisible();
 	});

--- a/tests/e2e/responsive.spec.ts
+++ b/tests/e2e/responsive.spec.ts
@@ -9,8 +9,6 @@ test.describe("Responsive layout", () => {
 		await expect(page.getByRole("heading", { name: "Characters" })).toBeVisible();
 		await expect(page.getByText("Thorin Ironforge")).toBeVisible();
 		await expect(page.getByRole("button", { name: "New Character" })).toBeVisible();
-
-		// Header should still be visible
 		await expect(page.getByText("D&D Character Manager")).toBeVisible();
 	});
 
@@ -22,8 +20,6 @@ test.describe("Responsive layout", () => {
 		await expect(page.getByLabel("Name")).toBeVisible();
 		await expect(page.getByLabel("Race")).toBeVisible();
 		await expect(page.getByLabel("Class")).toBeVisible();
-
-		// Ability score fields should be visible
 		await expect(page.getByLabel("Strength (STR)")).toBeVisible();
 		await expect(page.getByRole("button", { name: "Create Character" })).toBeVisible();
 	});
@@ -34,11 +30,16 @@ test.describe("Responsive layout", () => {
 		await page.goto(`/character/${character.id}`);
 
 		await expect(page.getByRole("heading", { name: "Thorin Ironforge" })).toBeVisible();
-		await expect(page.getByText("Ability Scores")).toBeVisible();
+		await expect(page.getByLabel("Combat vitals")).toBeVisible();
+		await expect(page.getByRole("tablist")).toBeVisible();
+		await expect(page.getByRole("tab", { name: "Combat" })).toBeVisible();
+		await expect(page.getByRole("tab", { name: "Stats" })).toBeVisible();
 		await expect(page.getByRole("heading", { name: "Hit Points" })).toBeVisible();
+
+		await page.getByRole("tab", { name: "Stats" }).click();
+		await expect(page.getByText("Ability Scores")).toBeVisible();
 		await expect(page.getByText("Skills")).toBeVisible();
 
-		// All content should be within viewport width
 		const mainWidth = await page.locator("main").evaluate((el) => el.scrollWidth);
 		expect(mainWidth).toBeLessThanOrEqual(375);
 	});
@@ -49,7 +50,9 @@ test.describe("Responsive layout", () => {
 		await page.goto(`/character/${character.id}`);
 
 		await expect(page.getByRole("heading", { name: "Thorin Ironforge" })).toBeVisible();
-		await expect(page.getByText("Ability Scores")).toBeVisible();
+		await expect(page.getByLabel("Combat vitals")).toBeVisible();
 		await expect(page.getByRole("heading", { name: "Hit Points" })).toBeVisible();
+		await page.getByRole("tab", { name: "Stats" }).click();
+		await expect(page.getByText("Ability Scores")).toBeVisible();
 	});
 });


### PR DESCRIPTION
## Summary
Closes #41

- **Combat Vitals Bar**: New always-visible bar at the top showing AC (shield), initiative modifier, HP bar with current/max, temp HP, concentration, and active condition count — the key stats players check every round
- **Tabbed sections**: Reorganized the long single-scroll layout into 4 tabs (Combat, Stats, Gear, Notes) using existing shadcn/ui Tabs component, dramatically reducing scroll distance during sessions
- **Information hierarchy**: Combat-critical info (HP controls, AC override, conditions, spell slots) grouped in the default "Combat" tab; ability scores, saves, and skills in "Stats"

## Test plan
- [ ] Verify CombatVitalsBar displays correct AC, initiative, HP values
- [ ] Verify tab navigation between Combat, Stats, Gear, Notes
- [ ] Verify all existing functionality (damage, heal, conditions, spell slots, equipment, notes) works within tabs
- [ ] Verify read-only/share view still works correctly
- [ ] Verify mobile responsive layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)