### PR TITLE
fix(ui): eliminate mobile horizontal scroll on character sheet

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -157,14 +157,16 @@
 		font: inherit;
 	}
 
-	/* Touch targets - minimum 44px for all interactive elements */
+	/* Touch targets - minimum 44px height for interactive elements.
+	   min-width omitted: it forces icon buttons wider than intended,
+	   causing horizontal overflow on narrow viewports. Components
+	   handle tap-area sizing via padding instead. */
 	button,
 	a,
 	input[type="checkbox"],
 	input[type="radio"],
 	select {
 		min-height: 44px;
-		min-width: 44px;
 	}
 
 	a {

--- a/src/app/responsive.test.ts
+++ b/src/app/responsive.test.ts
@@ -24,9 +24,12 @@ describe("US-007: Responsive setup and mobile navigation", () => {
 		expect(globalsCss).toContain("-moz-osx-font-smoothing: grayscale");
 	});
 
-	it("interactive elements have minimum 44px touch targets", () => {
+	it("interactive elements have minimum 44px touch target height", () => {
 		expect(globalsCss).toContain("min-height: 44px");
-		expect(globalsCss).toContain("min-width: 44px");
+	});
+
+	it("does not enforce min-width on touch targets (prevents mobile overflow)", () => {
+		expect(globalsCss).not.toContain("min-width: 44px");
 	});
 
 	it("App uses Tailwind responsive prefixes for mobile", () => {

--- a/src/domains/character/ui/EquipmentSection.test.ts
+++ b/src/domains/character/ui/EquipmentSection.test.ts
@@ -35,6 +35,16 @@ describe("EquipmentSection uses shadcn/ui components", () => {
 	it("imports Select component in form for categories", () => {
 		expect(formSource).toContain('from "../../../app/components/ui/select.tsx"');
 	});
+
+	it("hides Type and Weight columns on mobile to prevent overflow", () => {
+		const typeHidden = (source.match(/max-sm:hidden/g) || []).length;
+		expect(typeHidden).toBeGreaterThanOrEqual(4);
+	});
+
+	it("uses responsive grid columns for equipment table", () => {
+		expect(source).toContain("grid-cols-[1fr_auto_auto]");
+		expect(source).toContain("sm:grid-cols-[1fr_auto_auto_auto_auto]");
+	});
 });
 
 describe("globals.css has design tokens", () => {
@@ -47,5 +57,20 @@ describe("globals.css has design tokens", () => {
 
 	it("imports tailwindcss", () => {
 		expect(globalsCss).toContain('@import "tailwindcss"');
+	});
+
+	it("does not set min-width on touch targets to avoid mobile overflow", () => {
+		expect(globalsCss).not.toContain("min-width: 44px");
+	});
+});
+
+describe("ShareSection avoids mobile overflow", () => {
+	const shareSource = readFileSync(resolve(__dirname, "ShareSection.tsx"), "utf-8");
+
+	it("uses flex truncation without a fixed max-width on the code element", () => {
+		expect(shareSource).toContain("min-w-0");
+		expect(shareSource).toContain("overflow-hidden");
+		expect(shareSource).toContain("text-ellipsis");
+		expect(shareSource).not.toContain("max-w-[200px]");
 	});
 });

--- a/src/domains/character/ui/EquipmentSection.tsx
+++ b/src/domains/character/ui/EquipmentSection.tsx
@@ -118,11 +118,11 @@ export function EquipmentSection({
 
 			{equipment.length > 0 ? (
 				<div className="rounded-lg border border-border overflow-hidden mb-4">
-					<div className="grid grid-cols-[1fr_auto_auto_auto_auto] gap-2 px-3 py-2 bg-muted/50 text-xs font-semibold text-muted-foreground uppercase tracking-wider border-b border-border">
+					<div className="grid grid-cols-[1fr_auto_auto] sm:grid-cols-[1fr_auto_auto_auto_auto] gap-2 px-3 py-2 bg-muted/50 text-xs font-semibold text-muted-foreground uppercase tracking-wider border-b border-border">
 						<span>Item</span>
-						<span className="text-center w-16">Type</span>
+						<span className="text-center w-16 max-sm:hidden">Type</span>
 						<span className="text-center w-12">Qty</span>
-						<span className="text-right w-16">Weight</span>
+						<span className="text-right w-16 max-sm:hidden">Weight</span>
 						<span className="w-16">
 							<span className="sr-only">Actions</span>
 						</span>
@@ -166,7 +166,7 @@ function EquipmentRow({
 	return (
 		<div
 			className={cn(
-				"grid grid-cols-[1fr_auto_auto_auto_auto] gap-2 items-center px-3 min-h-[44px] transition-colors",
+				"grid grid-cols-[1fr_auto_auto] sm:grid-cols-[1fr_auto_auto_auto_auto] gap-2 items-center px-3 min-h-[44px] transition-colors",
 				index % 2 === 0 ? "bg-card" : "bg-muted/30",
 				item.equipped && "ring-1 ring-inset ring-primary/20",
 			)}
@@ -191,11 +191,11 @@ function EquipmentRow({
 					<p className="text-xs text-muted-foreground truncate">{item.description}</p>
 				)}
 			</div>
-			<span className="text-xs text-muted-foreground text-center w-16 truncate">
+			<span className="text-xs text-muted-foreground text-center w-16 truncate max-sm:hidden">
 				{ITEM_CATEGORY_LABELS[item.category] ?? item.category}
 			</span>
 			<span className="text-sm text-muted-foreground text-center w-12">x{item.quantity}</span>
-			<span className="text-sm text-muted-foreground text-right w-16">
+			<span className="text-sm text-muted-foreground text-right w-16 max-sm:hidden">
 				{item.weight * item.quantity} lbs
 			</span>
 			{!readOnly && (

--- a/src/domains/character/ui/ShareSection.tsx
+++ b/src/domains/character/ui/ShareSection.tsx
@@ -26,7 +26,7 @@ export function ShareSection({ slug }: { slug: string }) {
 		>
 			<span className="font-semibold text-muted-foreground whitespace-nowrap">Share:</span>
 			<code
-				className="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-sm text-foreground break-all max-w-[200px] sm:max-w-none font-mono"
+				className="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-sm text-foreground font-mono"
 				data-testid="share-url"
 			>
 				{shareUrl}


### PR DESCRIPTION
## Summary

Closes #39

- **Removed `min-width: 44px` from global touch-target CSS** — this rule forced icon buttons (e.g. 8×8 equip/remove buttons, 6×6 dice roll buttons) to 44px wide, causing cumulative overflow in tight layouts on 320–375px viewports. `min-height: 44px` is preserved; tap-area width is handled by component padding instead.
- **Made equipment table responsive** — switched from a fixed 5-column grid (`grid-cols-[1fr_auto_auto_auto_auto]`) to a 3-column mobile layout that hides Type and Weight columns via `max-sm:hidden`, preventing the ~240px of fixed-width columns from overflowing the ~288px inner container on mobile.
- **Removed `max-w-[200px]` from ShareSection `<code>` element** — the artificial cap conflicted with `flex-1`; the existing `min-w-0 overflow-hidden text-ellipsis` handles truncation correctly without it.

## Test plan

- [x] `pnpm lint` passes (Biome + architectural dep check)
- [x] `pnpm build` passes (tsc + Vite production build)
- [x] `pnpm test` passes — 501/501 tests, including:
  - New: equipment table uses responsive grid columns on mobile
  - New: equipment table hides Type/Weight columns on mobile (≥4 `max-sm:hidden` occurrences)
  - New: ShareSection code element uses flex truncation without fixed max-width
  - Updated: touch target test asserts no `min-width: 44px`
- [ ] Manual: verify no horizontal scroll at 320px and 375px on character sheet, character creation, and character list pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)