### PR TITLE
Add magic link login

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,20 +1,23 @@
 # Authentication
 
-Last verified: 2026-06-29
+Last verified: 2026-07-12
 
 This document describes the authentication system as it exists today. It is not a future account
 roadmap.
 
 ## Current State
 
-Authentication is implemented as an anonymous browser-session baseline:
+Authentication is implemented as an anonymous browser-session baseline with a visible magic-link
+account flow layered on top:
 
 - The server uses Better Auth with the anonymous plugin.
+- The server uses Better Auth's magic-link plugin for passwordless email sign-in.
 - Session and user records are stored in Postgres through the Drizzle adapter.
 - The browser receives a server-owned session cookie from Better Auth.
 - The React app bootstraps the current user with `GET /api/current-user`.
-- User-visible sign-up, sign-in, sign-out, account linking, recovery, and account settings do not
-  exist yet.
+- User-visible magic-link sign-in and sign-out exist.
+- Passwords, external identity providers, account recovery, profile settings, and session management
+  UI do not exist yet.
 
 This matches the MVP direction in [mvp.md](./mvp.md): scope character data to a browser session now
 and layer visible accounts on top later.
@@ -26,6 +29,8 @@ The server registers auth routes from `src/providers/auth/routes.ts`:
 | Route | Purpose |
 |-------|---------|
 | `/api/auth/*` | Pass-through route for Better Auth handlers |
+| `POST /api/magic-link-requests` | App-owned route that validates an email address and asks Better Auth to create a magic link |
+| `POST /api/sign-out` | App-owned route that signs out the current Better Auth session |
 | `GET /api/current-user` | App bootstrap route that returns or creates the current anonymous user |
 
 `GET /api/current-user` is intentionally stateful:
@@ -52,16 +57,33 @@ The public response shape is:
 The app does not expose Better Auth's internal session, token, account, or verification records to
 the browser.
 
+Magic-link sign-in is intentionally split between app-owned and Better Auth-owned routes:
+
+1. The browser posts an email address to `POST /api/magic-link-requests`.
+2. The route trims and lowercases the email address with a Zod boundary schema.
+3. The route calls `auth.api.signInMagicLink` with a root callback URL.
+4. Better Auth stores a single-use verification token in the `verification` table.
+5. Local development delivery writes the generated URL through structured logging under the
+   `auth.magic-link` logger. In production, log delivery is disabled unless
+   `MAGIC_LINK_ENABLE_LOG_DELIVERY=true` is set explicitly.
+6. The user opens the generated `/api/auth/magic-link/verify` link.
+7. Better Auth verifies and consumes the token, creates a session for the email account, sets the
+   session cookie, and redirects to `/`.
+8. If the browser had an anonymous session, the anonymous-link callback transfers owned characters
+   from the anonymous user ID to the linked account ID before Better Auth deletes the anonymous user.
+
 ## Frontend Flow
 
 `src/app/current-user-provider.tsx` calls the generated `apiQueries.getCurrentUser()` helper.
 `App` waits for this query before rendering character workflows.
 
-The UI treats the session as a browser-local workspace:
+The UI treats an anonymous session as a browser-local workspace:
 
 - While the query is loading, the app shows a session startup state.
 - If the query fails, the app shows a recoverable session error.
 - If the query succeeds, child UI can assume a current user exists.
+- Anonymous users see an email form for requesting a magic link.
+- Signed-in users see the account name and a sign-out action.
 
 The generated API client currently relies on same-origin requests. Development uses the Vite `/api`
 proxy, and production serves the built React app and API from the same Fastify origin. If the web app
@@ -81,8 +103,8 @@ Auth tables are defined in `src/providers/auth/schema.ts` and created by
 | `verification` | Future verification tokens such as email or recovery flows |
 
 The schema already supports account rows, provider IDs, tokens, and verification records because it
-uses Better Auth's table shape. The application does not currently provide any user-facing flow that
-creates or manages non-anonymous accounts.
+uses Better Auth's table shape. Magic-link requests now use `verification` rows as Better Auth's
+single-use token store.
 
 Deleting a `user` cascades to its `session`, `account`, and character records through foreign keys.
 
@@ -126,19 +148,22 @@ Production configuration is documented in [production.md](./production.md) and
 
 ## Account Management
 
-Account management is not implemented.
+Account management is limited to magic-link sign-in and sign-out.
 
-There is currently no:
+There is currently:
 
-- sign-up page
-- sign-in page
-- sign-out button
-- password or email flow
+- a magic-link email form for anonymous users
+- a sign-out button for signed-in users
+- automatic anonymous-to-account character transfer during magic-link verification
+
+There is not currently:
+
+- a separate sign-up page
+- password authentication
 - external identity provider
-- account linking flow
-- anonymous-to-permanent-account migration
 - profile or account settings UI
 - session management UI
+- production email delivery configuration
 
 The `account` and `verification` tables are present so those features can be layered in later without
 remodeling user ownership. Until then, the browser session cookie is the user's only handle to their
@@ -155,8 +180,14 @@ Current coverage includes:
 - Current-user response schema tests in `src/providers/auth/current-user.test.ts`.
 - Session cookie forwarding tests in `src/providers/auth/session.test.ts`.
 - Auth route adapter tests in `src/providers/auth/routes.test.ts`.
+- Magic-link schema and delivery unit tests in `src/providers/auth/magic-link-types.test.ts` and
+  `src/providers/auth/magic-link.test.ts`.
+- Magic-link route integration tests in `src/providers/auth/routes.integration.test.ts`.
 - Current-user provider UI tests in `src/app/current-user-provider.test.tsx`.
+- Magic-link login panel UI tests in `src/app/magic-link-login.test.tsx`.
 - Session reuse e2e coverage in `tests/e2e/session-flow.spec.ts`.
+- Magic-link sign-in and anonymous character transfer e2e coverage in
+  `tests/e2e/magic-link-login.spec.ts`.
 - Character route integration coverage proving another session user's character is not exposed.
 
 ## Known Limitations
@@ -164,6 +195,10 @@ Current coverage includes:
 - `GET /api/current-user` creates anonymous users as a side effect. This is intentional for the MVP,
   but production should eventually add cleanup, rate limiting, or another guard against unbounded
   anonymous account/session growth.
+- Magic-link delivery is local-development only by default: generated URLs are written to structured
+  logs outside production. Production needs an SMTP or transactional email adapter before users can
+  receive links by email; log delivery requires an explicit `MAGIC_LINK_ENABLE_LOG_DELIVERY=true`
+  opt-in.
 - There is no account recovery. Losing the browser cookie means losing access to that anonymous
   workspace through normal app flows.
 - There is no user-facing way to inspect, revoke, or transfer sessions.

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -20,7 +20,7 @@ Track the health of each domain and architectural layer. Update this when you im
 
 | Provider | Grade | Notes |
 |----------|-------|-------|
-| auth | B | Better Auth anonymous session provider, Postgres-backed tables, current-user bootstrap route, and current-state documentation are wired |
+| auth | B | Better Auth anonymous sessions, magic-link sign-in/sign-out, anonymous character transfer, Postgres-backed tables, and current-state documentation are wired; production email delivery remains future work |
 | database | B | Postgres provider wired through Docker Compose stack |
 | telemetry | B | Pino logger, request IDs, route timings, and stack log files are wired; metrics/traces are future work |
 | openapi | B | Route contracts generate `openapi.generated.json` and a typed frontend client; broader coverage should grow as domains are added |
@@ -32,9 +32,9 @@ Track the health of each domain and architectural layer. Update this when you im
 
 - [ ] Telemetry does not yet include a metrics/traces backend beyond structured logs and Playwright traces
 - [ ] No production metrics/traces backend
-- [ ] Auth has no anonymous user/session cleanup, recovery, or visible account management flow yet
+- [ ] Auth has no anonymous user/session cleanup, account recovery, profile settings, session management UI, or production email delivery yet
 - [ ] Character health does not yet include death saves, rest automation, damage types, or rules-derived max HP
 
 ---
 
-*Last updated: 2026-06-29*
+*Last updated: 2026-07-12*

--- a/src/api-contracts.test.ts
+++ b/src/api-contracts.test.ts
@@ -5,6 +5,8 @@ describe("apiRouteContracts", () => {
 	it("aggregates app route contracts for OpenAPI and client generation", () => {
 		expect(apiRouteContracts.map((route) => route.operationId)).toEqual([
 			"getCurrentUser",
+			"requestMagicLinkSignIn",
+			"signOutCurrentUser",
 			"createCharacter",
 			"listCharacters",
 			"getCharacter",

--- a/src/app-server.ts
+++ b/src/app-server.ts
@@ -1,10 +1,11 @@
-import { registerAuthRoutes } from "@providers/auth/index.js";
+import { registerAnonymousAccountLinkHandler, registerAuthRoutes } from "@providers/auth/index.js";
 import { closeDb } from "@providers/database/index.js";
 import { createOpenApiDocument } from "@providers/openapi/index.js";
 import { createLogger } from "@providers/telemetry/index.js";
 import Fastify from "fastify";
 import { apiRouteContracts } from "./api-contracts.js";
 import { registerCharacterRoutes } from "./domains/characters/runtime/index.js";
+import { createCharacterService } from "./domains/characters/service/index.js";
 import { registerStaticAssetFallback } from "./static-assets.js";
 
 const log = createLogger("app-server");
@@ -45,14 +46,21 @@ export async function buildServer(options: BuildServerOptions = {}) {
 			routes: apiRouteContracts,
 		}),
 	);
+	const characterService = createCharacterService();
+	const unregisterAccountLinkHandler = registerAnonymousAccountLinkHandler(
+		async ({ anonymousUserId, linkedUserId }) => {
+			await characterService.transferCharactersToUser(anonymousUserId, linkedUserId);
+		},
+	);
 	await registerAuthRoutes(app);
-	await registerCharacterRoutes(app);
+	await registerCharacterRoutes(app, { characterService });
 
 	if (options.staticRoot) {
 		registerStaticAssetFallback(app, options.staticRoot);
 	}
 
 	app.addHook("onClose", async () => {
+		unregisterAccountLinkHandler();
 		await closeDb();
 	});
 

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -7,6 +7,7 @@
 import { Alert, Badge, Container, Divider, Group, Paper, Stack, Text, Title } from "@mantine/core";
 import { CharacterWorkspace } from "../domains/characters/ui/index.js";
 import { useCurrentUser } from "./current-user-provider.js";
+import { MagicLinkLoginPanel } from "./magic-link-login.js";
 
 export function App() {
 	const { currentUser, error, isLoading } = useCurrentUser();
@@ -46,6 +47,7 @@ export function App() {
 					</Paper>
 				) : (
 					<Stack gap="md">
+						<MagicLinkLoginPanel currentUser={currentUser} />
 						<CharacterWorkspace />
 						<Text c="dimmed" size="xs">
 							Session user {currentUser.id}

--- a/src/app/magic-link-login.test.tsx
+++ b/src/app/magic-link-login.test.tsx
@@ -1,0 +1,40 @@
+import { MantineProvider } from "@mantine/core";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { MagicLinkLoginPanel } from "./magic-link-login.js";
+
+describe("MagicLinkLoginPanel", () => {
+	it("renders the magic link request form for anonymous users", () => {
+		const html = renderPanel({
+			id: "00000000-0000-4000-8000-000000000000",
+			isAnonymous: true,
+			name: "Anonymous",
+		});
+
+		expect(html).toContain("Email");
+		expect(html).toContain("Email sign-in link");
+	});
+
+	it("renders signed-in account controls for known users", () => {
+		const html = renderPanel({
+			id: "00000000-0000-4000-8000-000000000001",
+			isAnonymous: false,
+			name: "player@example.com",
+		});
+
+		expect(html).toContain("Signed in as player@example.com");
+		expect(html).toContain("Sign out");
+	});
+});
+
+function renderPanel(currentUser: { id: string; isAnonymous: boolean; name: string }) {
+	const queryClient = new QueryClient();
+	return renderToString(
+		<MantineProvider>
+			<QueryClientProvider client={queryClient}>
+				<MagicLinkLoginPanel currentUser={currentUser} />
+			</QueryClientProvider>
+		</MantineProvider>,
+	);
+}

--- a/src/app/magic-link-login.tsx
+++ b/src/app/magic-link-login.tsx
@@ -1,0 +1,110 @@
+import { Alert, Box, Button, Group, Paper, Stack, Text, TextInput } from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+	apiMutations,
+	apiQueries,
+	type CurrentUserResponse,
+} from "../generated/api-client.generated.js";
+
+type CurrentUser = CurrentUserResponse["user"];
+
+interface MagicLinkLoginPanelProps {
+	currentUser: CurrentUser;
+}
+
+interface MagicLinkFormValues {
+	email: string;
+}
+
+export function MagicLinkLoginPanel({ currentUser }: MagicLinkLoginPanelProps) {
+	const queryClient = useQueryClient();
+	const form = useForm<MagicLinkFormValues>({
+		mode: "controlled",
+		initialValues: { email: "" },
+		validate: {
+			email: validateEmail,
+		},
+	});
+	const requestMagicLinkMutation = useMutation({
+		...apiMutations.requestMagicLinkSignIn(),
+		onSuccess: () => {
+			form.reset();
+		},
+	});
+	const signOutMutation = useMutation({
+		...apiMutations.signOutCurrentUser(),
+		onSuccess: async () => {
+			await queryClient.invalidateQueries({ queryKey: ["api"] });
+			await queryClient.ensureQueryData(apiQueries.getCurrentUser());
+		},
+	});
+
+	if (!currentUser.isAnonymous) {
+		return (
+			<Paper withBorder p="md">
+				<Group justify="space-between" align="center">
+					<Stack gap={2}>
+						<Text fw={600}>{`Signed in as ${currentUser.name}`}</Text>
+						<Text c="dimmed" size="sm">
+							Your character workspace is connected to this account.
+						</Text>
+					</Stack>
+					<Button
+						loading={signOutMutation.isPending}
+						onClick={() => signOutMutation.mutate()}
+						variant="light"
+					>
+						Sign out
+					</Button>
+				</Group>
+			</Paper>
+		);
+	}
+
+	return (
+		<Paper withBorder p="md">
+			<Stack gap="md">
+				{requestMagicLinkMutation.isSuccess && (
+					<Alert color="green" title="Sign-in link sent" variant="light">
+						Open the link to finish signing in.
+					</Alert>
+				)}
+				{requestMagicLinkMutation.error && (
+					<Alert color="red" title="Sign-in link unavailable" variant="light">
+						Check the email address and try again.
+					</Alert>
+				)}
+				<Box
+					component="form"
+					onSubmit={form.onSubmit((values) => {
+						requestMagicLinkMutation.mutate({ email: values.email.trim() });
+					})}
+				>
+					<Group align="flex-end" wrap="wrap">
+						<TextInput
+							{...form.getInputProps("email")}
+							autoComplete="email"
+							flex={1}
+							label="Email"
+							miw={220}
+							placeholder="player@example.com"
+							type="email"
+							withAsterisk
+						/>
+						<Button loading={requestMagicLinkMutation.isPending} type="submit">
+							Email sign-in link
+						</Button>
+					</Group>
+				</Box>
+			</Stack>
+		</Paper>
+	);
+}
+
+export function validateEmail(value: string) {
+	const email = value.trim();
+	if (email.length === 0) return "Email is required";
+	if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return "Enter a valid email";
+	return null;
+}

--- a/src/domains/characters/repo/character-repository.integration.test.ts
+++ b/src/domains/characters/repo/character-repository.integration.test.ts
@@ -57,6 +57,46 @@ describe("createCharacterRepository", () => {
 			health: { currentHp: 28, maxHp: 28, temporaryHp: 0, effectiveMaxHp: 28 },
 		});
 	});
+
+	it("transfers all characters from an anonymous user to a linked account", async () => {
+		const anonymousUserId = await createUser();
+		const linkedUserId = await createUser();
+		const repository = createCharacterRepository();
+		const firstCharacter = await repository.createCharacter({
+			userId: anonymousUserId,
+			name: "Mira",
+			className: "Fighter",
+			level: 3,
+			maxHp: 28,
+		});
+		const secondCharacter = await repository.createCharacter({
+			userId: anonymousUserId,
+			name: "Nyx",
+			className: "Rogue",
+			level: 4,
+			maxHp: 24,
+		});
+
+		await expect(repository.transferCharactersToUser(anonymousUserId, linkedUserId)).resolves.toBe(
+			2,
+		);
+
+		await expect(repository.listCharacters(anonymousUserId)).resolves.toEqual([]);
+		await expect(repository.listCharacters(linkedUserId)).resolves.toEqual([
+			{
+				id: firstCharacter.id,
+				name: "Mira",
+				className: "Fighter",
+				level: 3,
+			},
+			{
+				id: secondCharacter.id,
+				name: "Nyx",
+				className: "Rogue",
+				level: 4,
+			},
+		]);
+	});
 });
 
 async function createUser() {

--- a/src/domains/characters/repo/character-repository.ts
+++ b/src/domains/characters/repo/character-repository.ts
@@ -14,6 +14,7 @@ export interface CharacterRepository {
 	createCharacter(input: CreateCharacterRecord): Promise<CharacterDetail>;
 	listCharacters(userId: string): Promise<CharacterSummary[]>;
 	findCharacterDetail(userId: string, characterId: string): Promise<CharacterDetail | null>;
+	transferCharactersToUser(fromUserId: string, toUserId: string): Promise<number>;
 }
 
 export function createCharacterRepository(
@@ -88,6 +89,16 @@ export function createCharacterRepository(
 			if (!row) return null;
 
 			return toCharacterDetail(row, await healthRepository.listRecentHealthChanges(characterId));
+		},
+
+		async transferCharactersToUser(fromUserId, toUserId) {
+			const transferred = await getDb()
+				.update(charactersTable)
+				.set({ userId: toUserId, updatedAt: new Date() })
+				.where(eq(charactersTable.userId, fromUserId))
+				.returning({ id: charactersTable.id });
+
+			return transferred.length;
 		},
 	};
 }

--- a/src/domains/characters/runtime/routes.test.ts
+++ b/src/domains/characters/runtime/routes.test.ts
@@ -160,6 +160,7 @@ function fakeService() {
 		createCharacter: vi.fn(),
 		getCharacter: vi.fn(),
 		listCharacters: vi.fn(),
+		transferCharactersToUser: vi.fn(),
 	} satisfies CharacterService;
 }
 

--- a/src/domains/characters/service/character-service.test.ts
+++ b/src/domains/characters/service/character-service.test.ts
@@ -35,4 +35,31 @@ describe("createCharacterService", () => {
 			maxHp: 18,
 		});
 	});
+
+	it("delegates anonymous character transfer for linked accounts", async () => {
+		const repository = {
+			transferCharactersToUser: vi.fn(async () => 2),
+		} as unknown as CharacterRepository;
+
+		await expect(
+			createCharacterService(repository).transferCharactersToUser("anonymous-user", "linked-user"),
+		).resolves.toBe(2);
+
+		expect(repository.transferCharactersToUser).toHaveBeenCalledWith(
+			"anonymous-user",
+			"linked-user",
+		);
+	});
+
+	it("skips transfer when the anonymous and linked account ids match", async () => {
+		const repository = {
+			transferCharactersToUser: vi.fn(async () => 1),
+		} as unknown as CharacterRepository;
+
+		await expect(
+			createCharacterService(repository).transferCharactersToUser("same-user", "same-user"),
+		).resolves.toBe(0);
+
+		expect(repository.transferCharactersToUser).not.toHaveBeenCalled();
+	});
 });

--- a/src/domains/characters/service/character-service.ts
+++ b/src/domains/characters/service/character-service.ts
@@ -7,6 +7,7 @@ export interface CharacterService {
 	createCharacter(userId: string, input: CreateCharacterRequest): Promise<CharacterDetail>;
 	listCharacters(userId: string): Promise<CharacterSummary[]>;
 	getCharacter(userId: string, characterId: string): Promise<CharacterDetail>;
+	transferCharactersToUser(fromUserId: string, toUserId: string): Promise<number>;
 }
 
 export function createCharacterService(
@@ -31,6 +32,11 @@ export function createCharacterService(
 			const character = await repository.findCharacterDetail(userId, characterId);
 			if (!character) throw new CharacterNotFoundError();
 			return character;
+		},
+
+		transferCharactersToUser(fromUserId, toUserId) {
+			if (fromUserId === toUserId) return Promise.resolve(0);
+			return repository.transferCharactersToUser(fromUserId, toUserId);
 		},
 	};
 }

--- a/src/domains/characters/ui/character-detail.tsx
+++ b/src/domains/characters/ui/character-detail.tsx
@@ -38,7 +38,7 @@ export function CharacterDetail({ id, onNavigate }: CharacterDetailProps) {
 				</Alert>
 			)}
 
-			{characterQuery.data && (
+			{characterQuery.data && !characterQuery.error && (
 				<Paper withBorder p="lg">
 					<Stack gap="md">
 						<Title order={3}>{characterQuery.data.character.name}</Title>

--- a/src/generated/api-client.generated.ts
+++ b/src/generated/api-client.generated.ts
@@ -5,6 +5,9 @@ import { mutationOptions, queryOptions } from "@tanstack/react-query";
 import type { CurrentUserResponse } from "../providers/auth/current-user.js";
 export type { CurrentUserResponse } from "../providers/auth/current-user.js";
 import { CurrentUserResponseSchema } from "../providers/auth/current-user.js";
+import type { MagicLinkRequest, MagicLinkRequestResponse, SignOutResponse } from "../providers/auth/magic-link-types.js";
+export type { MagicLinkRequest, MagicLinkRequestResponse, SignOutResponse } from "../providers/auth/magic-link-types.js";
+import { MagicLinkRequestResponseSchema, SignOutResponseSchema } from "../providers/auth/magic-link-types.js";
 import type { CharacterDetailResponse, CreateCharacterRequest, ListCharactersResponse, UpdateCharacterHealthRequest, UpdateCharacterHealthResponse } from "../domains/characters/types/index.js";
 export type { CharacterDetailResponse, CreateCharacterRequest, ListCharactersResponse, UpdateCharacterHealthRequest, UpdateCharacterHealthResponse } from "../domains/characters/types/index.js";
 import { CharacterDetailResponseSchema, ListCharactersResponseSchema, UpdateCharacterHealthResponseSchema } from "../domains/characters/types/index.js";
@@ -38,6 +41,14 @@ export function createApiClient(options: ApiClientOptions = {}) {
 	return {
 		getCurrentUser(options: ApiRequestOptions = {}): Promise<CurrentUserResponse> {
 			return request<CurrentUserResponse>(fetchImpl, baseUrl, "GET", "/api/current-user", options, undefined, (body: unknown) => CurrentUserResponseSchema.parse(body));
+		},
+
+		requestMagicLinkSignIn(body: MagicLinkRequest, options: ApiRequestOptions = {}): Promise<MagicLinkRequestResponse> {
+			return request<MagicLinkRequestResponse>(fetchImpl, baseUrl, "POST", "/api/magic-link-requests", options, body, (body: unknown) => MagicLinkRequestResponseSchema.parse(body));
+		},
+
+		signOutCurrentUser(options: ApiRequestOptions = {}): Promise<SignOutResponse> {
+			return request<SignOutResponse>(fetchImpl, baseUrl, "POST", "/api/sign-out", options, undefined, (body: unknown) => SignOutResponseSchema.parse(body));
 		},
 
 		createCharacter(body: CreateCharacterRequest, options: ApiRequestOptions = {}): Promise<CharacterDetailResponse> {
@@ -89,6 +100,16 @@ export const apiQueries = createApiQueryOptions();
 
 export function createApiMutationOptions(client = apiClient) {
 	return {
+		requestMagicLinkSignIn: (options: ApiRequestOptions = {}) => mutationOptions({
+			mutationKey: ["api", "requestMagicLinkSignIn"] as const,
+			mutationFn: (body: MagicLinkRequest) => client.requestMagicLinkSignIn(body, options),
+		}),
+
+		signOutCurrentUser: (options: ApiRequestOptions = {}) => mutationOptions({
+			mutationKey: ["api", "signOutCurrentUser"] as const,
+			mutationFn: () => client.signOutCurrentUser(options),
+		}),
+
 		createCharacter: (options: ApiRequestOptions = {}) => mutationOptions({
 			mutationKey: ["api", "createCharacter"] as const,
 			mutationFn: (body: CreateCharacterRequest) => client.createCharacter(body, options),

--- a/src/generated/openapi.generated.json
+++ b/src/generated/openapi.generated.json
@@ -54,6 +54,91 @@
 				}
 			}
 		},
+		"/api/magic-link-requests": {
+			"post": {
+				"operationId": "requestMagicLinkSignIn",
+				"summary": "Request magic link sign-in",
+				"tags": [
+					"auth"
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"email": {
+										"type": "string",
+										"format": "email",
+										"pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
+									}
+								},
+								"required": [
+									"email"
+								],
+								"additionalProperties": false
+							}
+						}
+					}
+				},
+				"responses": {
+					"202": {
+						"description": "Magic link request accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"status": {
+											"type": "string",
+											"const": "sent"
+										}
+									},
+									"required": [
+										"status"
+									],
+									"additionalProperties": false
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Invalid request body"
+					}
+				}
+			}
+		},
+		"/api/sign-out": {
+			"post": {
+				"operationId": "signOutCurrentUser",
+				"summary": "Sign out current user",
+				"tags": [
+					"auth"
+				],
+				"responses": {
+					"200": {
+						"description": "Signed out current user",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"signedOut": {
+											"type": "boolean"
+										}
+									},
+									"required": [
+										"signedOut"
+									],
+									"additionalProperties": false
+								}
+							}
+						}
+					}
+				}
+			}
+		},
 		"/api/characters": {
 			"post": {
 				"operationId": "createCharacter",

--- a/src/providers/auth/account-linking.test.ts
+++ b/src/providers/auth/account-linking.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	handleAnonymousAccountLinked,
+	registerAnonymousAccountLinkHandler,
+	resetAnonymousAccountLinkHandlersForTest,
+} from "./account-linking.js";
+
+describe("anonymous account linking handlers", () => {
+	it("notifies registered handlers and allows unregistering", async () => {
+		resetAnonymousAccountLinkHandlersForTest();
+		const handler = vi.fn();
+		const unregister = registerAnonymousAccountLinkHandler(handler);
+
+		await handleAnonymousAccountLinked({
+			anonymousUserId: "anonymous-user",
+			linkedUserId: "linked-user",
+		});
+		unregister();
+		await handleAnonymousAccountLinked({
+			anonymousUserId: "anonymous-user",
+			linkedUserId: "linked-user",
+		});
+
+		expect(handler).toHaveBeenCalledOnce();
+		expect(handler).toHaveBeenCalledWith({
+			anonymousUserId: "anonymous-user",
+			linkedUserId: "linked-user",
+		});
+	});
+});

--- a/src/providers/auth/account-linking.ts
+++ b/src/providers/auth/account-linking.ts
@@ -1,0 +1,25 @@
+export interface AnonymousAccountLink {
+	anonymousUserId: string;
+	linkedUserId: string;
+}
+
+export type AnonymousAccountLinkHandler = (link: AnonymousAccountLink) => Promise<void> | void;
+
+const accountLinkHandlers = new Set<AnonymousAccountLinkHandler>();
+
+export function registerAnonymousAccountLinkHandler(handler: AnonymousAccountLinkHandler) {
+	accountLinkHandlers.add(handler);
+	return () => {
+		accountLinkHandlers.delete(handler);
+	};
+}
+
+export async function handleAnonymousAccountLinked(link: AnonymousAccountLink) {
+	for (const handler of accountLinkHandlers) {
+		await handler(link);
+	}
+}
+
+export function resetAnonymousAccountLinkHandlersForTest() {
+	accountLinkHandlers.clear();
+}

--- a/src/providers/auth/auth.ts
+++ b/src/providers/auth/auth.ts
@@ -1,7 +1,9 @@
 import { getDb } from "@providers/database/index.js";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { anonymous } from "better-auth/plugins";
+import { anonymous, magicLink } from "better-auth/plugins";
+import { handleAnonymousAccountLinked } from "./account-linking.js";
+import { sendMagicLinkWithLogger } from "./magic-link.js";
 import { authTables } from "./schema.js";
 
 const LOCAL_AUTH_SECRET = "local-development-auth-secret-for-dnd-character-manager";
@@ -24,7 +26,19 @@ function createAuth() {
 				generateId: "uuid",
 			},
 		},
-		plugins: [anonymous()],
+		plugins: [
+			anonymous({
+				onLinkAccount: async ({ anonymousUser, newUser }) => {
+					await handleAnonymousAccountLinked({
+						anonymousUserId: anonymousUser.user.id,
+						linkedUserId: newUser.user.id,
+					});
+				},
+			}),
+			magicLink({
+				sendMagicLink: (delivery) => sendMagicLinkWithLogger(delivery),
+			}),
+		],
 		trustedOrigins: getTrustedOrigins(),
 	});
 }

--- a/src/providers/auth/contract.test.ts
+++ b/src/providers/auth/contract.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { authRouteContracts } from "./contract.js";
 
 describe("authRouteContracts", () => {
-	it("exposes a browser-callable current-user route", () => {
+	it("exposes browser-callable auth routes", () => {
 		expect(authRouteContracts).toMatchObject([
 			{
 				method: "get",
@@ -11,6 +11,25 @@ describe("authRouteContracts", () => {
 				client: {
 					functionName: "getCurrentUser",
 					responseType: "CurrentUserResponse",
+				},
+			},
+			{
+				method: "post",
+				operationId: "requestMagicLinkSignIn",
+				path: "/api/magic-link-requests",
+				client: {
+					functionName: "requestMagicLinkSignIn",
+					requestBodyType: "MagicLinkRequest",
+					responseType: "MagicLinkRequestResponse",
+				},
+			},
+			{
+				method: "post",
+				operationId: "signOutCurrentUser",
+				path: "/api/sign-out",
+				client: {
+					functionName: "signOutCurrentUser",
+					responseType: "SignOutResponse",
 				},
 			},
 		]);

--- a/src/providers/auth/contract.ts
+++ b/src/providers/auth/contract.ts
@@ -1,5 +1,10 @@
 import type { ApiRouteContract } from "@providers/openapi/index.js";
 import { CurrentUserResponseSchema } from "./current-user.js";
+import {
+	MagicLinkRequestResponseSchema,
+	MagicLinkRequestSchema,
+	SignOutResponseSchema,
+} from "./magic-link-types.js";
 
 const currentUserImports = [
 	{
@@ -11,6 +16,19 @@ const currentUserImports = [
 		kind: "value",
 		module: "../providers/auth/current-user.js",
 		names: ["CurrentUserResponseSchema"],
+	},
+] as const;
+
+const magicLinkImports = [
+	{
+		kind: "type",
+		module: "../providers/auth/magic-link-types.js",
+		names: ["MagicLinkRequest", "MagicLinkRequestResponse", "SignOutResponse"],
+	},
+	{
+		kind: "value",
+		module: "../providers/auth/magic-link-types.js",
+		names: ["MagicLinkRequestResponseSchema", "SignOutResponseSchema"],
 	},
 ] as const;
 
@@ -29,6 +47,44 @@ export const authRouteContracts = [
 			imports: currentUserImports,
 			responseParser: "CurrentUserResponseSchema",
 			responseType: "CurrentUserResponse",
+		},
+	},
+	{
+		method: "post",
+		operationId: "requestMagicLinkSignIn",
+		path: "/api/magic-link-requests",
+		requestBody: MagicLinkRequestSchema,
+		responses: {
+			202: {
+				description: "Magic link request accepted",
+				schema: MagicLinkRequestResponseSchema,
+			},
+			400: { description: "Invalid request body" },
+		},
+		summary: "Request magic link sign-in",
+		tags: ["auth"],
+		client: {
+			functionName: "requestMagicLinkSignIn",
+			imports: magicLinkImports,
+			requestBodyType: "MagicLinkRequest",
+			responseParser: "MagicLinkRequestResponseSchema",
+			responseType: "MagicLinkRequestResponse",
+		},
+	},
+	{
+		method: "post",
+		operationId: "signOutCurrentUser",
+		path: "/api/sign-out",
+		responses: {
+			200: { description: "Signed out current user", schema: SignOutResponseSchema },
+		},
+		summary: "Sign out current user",
+		tags: ["auth"],
+		client: {
+			functionName: "signOutCurrentUser",
+			imports: magicLinkImports,
+			responseParser: "SignOutResponseSchema",
+			responseType: "SignOutResponse",
 		},
 	},
 ] as const satisfies readonly ApiRouteContract[];

--- a/src/providers/auth/index.ts
+++ b/src/providers/auth/index.ts
@@ -1,6 +1,12 @@
+export { registerAnonymousAccountLinkHandler } from "./account-linking.js";
 export { getAuth } from "./auth.js";
 export { authRouteContracts } from "./contract.js";
 export type { CurrentUser, CurrentUserResponse } from "./current-user.js";
 export { CurrentUserResponseSchema, CurrentUserSchema } from "./current-user.js";
+export type {
+	MagicLinkRequest,
+	MagicLinkRequestResponse,
+	SignOutResponse,
+} from "./magic-link-types.js";
 export { registerAuthRoutes } from "./routes.js";
 export { getOrCreateCurrentUser } from "./session.js";

--- a/src/providers/auth/magic-link-types.test.ts
+++ b/src/providers/auth/magic-link-types.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { MagicLinkRequestSchema } from "./magic-link-types.js";
+
+describe("MagicLinkRequestSchema", () => {
+	it("normalizes email addresses before requesting a link", () => {
+		expect(MagicLinkRequestSchema.parse({ email: " Player@Example.COM " })).toEqual({
+			email: "player@example.com",
+		});
+	});
+
+	it("rejects invalid email input", () => {
+		expect(() => MagicLinkRequestSchema.parse({ email: "not-an-email" })).toThrow();
+	});
+});

--- a/src/providers/auth/magic-link-types.ts
+++ b/src/providers/auth/magic-link-types.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const MagicLinkRequestSchema = z.object({
+	email: z.string().trim().toLowerCase().pipe(z.email()),
+});
+
+export type MagicLinkRequest = z.infer<typeof MagicLinkRequestSchema>;
+
+export const MagicLinkRequestResponseSchema = z.object({
+	status: z.literal("sent"),
+});
+
+export type MagicLinkRequestResponse = z.infer<typeof MagicLinkRequestResponseSchema>;
+
+export const SignOutResponseSchema = z.object({
+	signedOut: z.boolean(),
+});
+
+export type SignOutResponse = z.infer<typeof SignOutResponseSchema>;

--- a/src/providers/auth/magic-link.test.ts
+++ b/src/providers/auth/magic-link.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { getMagicLinkDisplayName, sendMagicLinkWithLogger } from "./magic-link.js";
+
+describe("getMagicLinkDisplayName", () => {
+	it("uses the normalized email as the account display name", () => {
+		expect(getMagicLinkDisplayName("player@example.com")).toBe("player@example.com");
+	});
+});
+
+describe("sendMagicLinkWithLogger", () => {
+	it("writes the generated URL with structured logging", async () => {
+		const info = vi.fn();
+
+		await sendMagicLinkWithLogger(
+			{
+				email: "player@example.com",
+				token: "secret-token",
+				url: "http://localhost/api/auth/magic-link/verify?token=secret-token",
+			},
+			{ info } as never,
+		);
+
+		expect(info).toHaveBeenCalledWith(
+			{
+				email: "player@example.com",
+				magicLinkUrl: "http://localhost/api/auth/magic-link/verify?token=secret-token",
+			},
+			"Magic link login URL generated",
+		);
+	});
+
+	it("rejects log delivery in production unless explicitly enabled", async () => {
+		const info = vi.fn();
+
+		await expect(
+			sendMagicLinkWithLogger(
+				{
+					email: "player@example.com",
+					token: "secret-token",
+					url: "http://localhost/api/auth/magic-link/verify?token=secret-token",
+				},
+				{ info } as never,
+				{ NODE_ENV: "production" },
+			),
+		).rejects.toThrow("Magic link log delivery is disabled in production.");
+
+		expect(info).not.toHaveBeenCalled();
+	});
+});

--- a/src/providers/auth/magic-link.ts
+++ b/src/providers/auth/magic-link.ts
@@ -1,0 +1,81 @@
+import { fromNodeHeaders } from "better-auth/node";
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { createLogger, type Logger } from "../telemetry/index.js";
+import { getAuth } from "./auth.js";
+import {
+	type MagicLinkRequestResponse,
+	MagicLinkRequestSchema,
+	type SignOutResponse,
+} from "./magic-link-types.js";
+import { forwardSetCookieHeaders } from "./session.js";
+
+export interface MagicLinkDelivery {
+	email: string;
+	token: string;
+	url: string;
+}
+
+type MagicLinkDeliveryEnv = Readonly<Record<string, string | undefined>>;
+
+const magicLinkLogger = createLogger("auth.magic-link");
+
+export async function sendMagicLinkWithLogger(
+	delivery: MagicLinkDelivery,
+	logger: Pick<Logger, "info"> = magicLinkLogger,
+	env: MagicLinkDeliveryEnv = process.env,
+) {
+	if (!isLogDeliveryEnabled(env)) {
+		throw new Error("Magic link log delivery is disabled in production.");
+	}
+
+	logger.info(
+		{
+			email: delivery.email,
+			magicLinkUrl: delivery.url,
+		},
+		"Magic link login URL generated",
+	);
+}
+
+export function isLogDeliveryEnabled(env: MagicLinkDeliveryEnv = process.env) {
+	return env.NODE_ENV !== "production" || env.MAGIC_LINK_ENABLE_LOG_DELIVERY === "true";
+}
+
+export function getMagicLinkDisplayName(email: string) {
+	return email;
+}
+
+export async function requestMagicLinkSignIn(request: FastifyRequest, reply: FastifyReply) {
+	const result = MagicLinkRequestSchema.safeParse(request.body);
+	if (!result.success) {
+		return reply.status(400).send({ error: "Invalid request body." });
+	}
+
+	await getAuth().api.signInMagicLink({
+		body: {
+			email: result.data.email,
+			name: getMagicLinkDisplayName(result.data.email),
+			callbackURL: "/",
+		},
+		headers: fromNodeHeaders(request.headers),
+	});
+
+	return reply.status(202).send({ status: "sent" } satisfies MagicLinkRequestResponse);
+}
+
+export async function signOutCurrentUser(request: FastifyRequest, reply: FastifyReply) {
+	const response = await getAuth().handler(toBetterAuthSignOutRequest(request));
+	reply.status(response.status);
+	forwardSetCookieHeaders(response.headers, reply);
+
+	const body = (await response.json()) as { success?: boolean };
+	return { signedOut: Boolean(body.success) } satisfies SignOutResponse;
+}
+
+function toBetterAuthSignOutRequest(request: FastifyRequest) {
+	const url = new URL("/api/auth/sign-out", `http://${request.headers.host ?? "localhost"}`);
+	return new Request(url.toString(), {
+		method: "POST",
+		headers: fromNodeHeaders(request.headers),
+	});
+}

--- a/src/providers/auth/routes.integration.test.ts
+++ b/src/providers/auth/routes.integration.test.ts
@@ -1,0 +1,120 @@
+import { resetAuthForTest } from "@providers/auth/auth.js";
+import { userTable, verificationTable } from "@providers/auth/schema.js";
+import { closeDb, getDb } from "@providers/database/index.js";
+import { inArray } from "drizzle-orm";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildServer } from "../../app-server.js";
+
+const createdUserIds: string[] = [];
+
+afterEach(async () => {
+	resetAuthForTest();
+	await getDb().delete(verificationTable);
+	if (createdUserIds.length > 0) {
+		await getDb()
+			.delete(userTable)
+			.where(inArray(userTable.id, [...createdUserIds]));
+		createdUserIds.length = 0;
+	}
+	await closeDb();
+});
+
+describe("auth routes", () => {
+	it("creates a magic link verification request for a normalized email", async () => {
+		const app = await buildServer();
+		try {
+			const response = await app.inject({
+				method: "POST",
+				url: "/api/magic-link-requests",
+				payload: { email: " Player@Example.COM " },
+			});
+
+			expect(response.statusCode).toBe(202);
+			expect(response.json()).toEqual({ status: "sent" });
+
+			const rows = await getDb()
+				.select({
+					identifier: verificationTable.identifier,
+					value: verificationTable.value,
+				})
+				.from(verificationTable);
+			const emailValues = rows.map((row) => JSON.parse(row.value).email);
+
+			expect(emailValues).toContain("player@example.com");
+		} finally {
+			await app.close();
+		}
+	});
+
+	it("rejects invalid magic link request bodies", async () => {
+		const app = await buildServer();
+		try {
+			const response = await app.inject({
+				method: "POST",
+				url: "/api/magic-link-requests",
+				payload: { email: "not-an-email" },
+			});
+
+			expect(response.statusCode).toBe(400);
+			expect(response.json()).toEqual({ error: "Invalid request body." });
+		} finally {
+			await app.close();
+		}
+	});
+
+	it("does not expose Better Auth's native magic-link request endpoint", async () => {
+		const app = await buildServer();
+		try {
+			const response = await app.inject({
+				method: "POST",
+				url: "/api/auth/sign-in/magic-link",
+				payload: { email: "Player@Example.COM" },
+			});
+
+			expect(response.statusCode).toBe(404);
+
+			const rows = await getDb().select({ id: verificationTable.id }).from(verificationTable);
+			expect(rows).toEqual([]);
+		} finally {
+			await app.close();
+		}
+	});
+
+	it("signs out the current session and allows a new anonymous session", async () => {
+		const app = await buildServer();
+		try {
+			const currentUser = await app.inject({ method: "GET", url: "/api/current-user" });
+			expect(currentUser.statusCode).toBe(200);
+			const firstUserId = currentUser.json().user.id;
+			createdUserIds.push(firstUserId);
+
+			const signOut = await app.inject({
+				method: "POST",
+				url: "/api/sign-out",
+				headers: { cookie: toCookieHeader(currentUser.headers["set-cookie"]) },
+			});
+
+			expect(signOut.statusCode).toBe(200);
+			expect(signOut.json()).toEqual({ signedOut: true });
+			expect(signOut.headers["set-cookie"]).toBeDefined();
+
+			const nextUser = await app.inject({
+				method: "GET",
+				url: "/api/current-user",
+				headers: { cookie: toCookieHeader(signOut.headers["set-cookie"]) },
+			});
+			expect(nextUser.statusCode).toBe(200);
+			const nextUserBody = nextUser.json();
+			createdUserIds.push(nextUserBody.user.id);
+			expect(nextUserBody.user).toMatchObject({ isAnonymous: true });
+			expect(nextUserBody.user.id).not.toBe(firstUserId);
+		} finally {
+			await app.close();
+		}
+	});
+});
+
+function toCookieHeader(setCookie: string | string[] | undefined) {
+	const cookies = Array.isArray(setCookie) ? setCookie : setCookie ? [setCookie] : [];
+	return cookies.map((cookie) => cookie.split(";")[0]).join("; ");
+}

--- a/src/providers/auth/routes.ts
+++ b/src/providers/auth/routes.ts
@@ -1,9 +1,26 @@
 import { fromNodeHeaders } from "better-auth/node";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { getAuth } from "./auth.js";
+import { requestMagicLinkSignIn, signOutCurrentUser } from "./magic-link.js";
 import { getOrCreateCurrentUser } from "./session.js";
 
 export async function registerAuthRoutes(app: FastifyInstance) {
+	app.post("/api/magic-link-requests", async (request, reply) => {
+		return requestMagicLinkSignIn(request, reply);
+	});
+
+	app.post("/api/sign-out", async (request, reply) => {
+		return signOutCurrentUser(request, reply);
+	});
+
+	app.route({
+		method: ["GET", "POST"],
+		url: "/api/auth/sign-in/magic-link",
+		handler: async (_request, reply) => {
+			return reply.status(404).send({ error: "Not found" });
+		},
+	});
+
 	app.route({
 		method: ["GET", "POST"],
 		url: "/api/auth/*",

--- a/tests/e2e/magic-link-login.spec.ts
+++ b/tests/e2e/magic-link-login.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+import postgres from "postgres";
+
+test("signs in with a magic link and keeps anonymous characters", async ({ page }) => {
+	const email = `player-${Date.now()}@example.test`;
+
+	await page.goto("/");
+	await page.getByText("Create character").first().click();
+	await page.getByLabel("Name").fill("Linkward Bard");
+	await page.getByRole("combobox", { name: "Class" }).click();
+	await page.getByRole("option", { name: "Bard" }).click();
+	await page.getByRole("button", { name: "Create character" }).click();
+	await expect(page.getByRole("heading", { name: "Linkward Bard" })).toBeVisible();
+
+	await page.getByText("Back to characters").click();
+	await page.getByLabel("Email").fill(email);
+	await page.getByRole("button", { name: "Email sign-in link" }).click();
+	await expect(page.getByText("Sign-in link sent")).toBeVisible();
+
+	const token = await readMagicLinkToken(email);
+	await page.goto(`/api/auth/magic-link/verify?token=${token}&callbackURL=/`);
+
+	await expect(page).toHaveURL(/\/$/);
+	await expect(page.getByText(`Signed in as ${email}`)).toBeVisible();
+	await expect(page.getByRole("link", { name: "Linkward Bard" })).toBeVisible();
+
+	await page.getByRole("link", { name: "Linkward Bard" }).click();
+	await expect(page.getByRole("heading", { name: "Linkward Bard" })).toBeVisible();
+
+	await page.getByRole("button", { name: "Sign out" }).click();
+
+	await expect(page.getByText("Anonymous session")).toBeVisible();
+	await expect(page.getByLabel("Email")).toBeVisible();
+	await expect(page.getByText("Character not found")).toBeVisible();
+	await expect(page.getByRole("heading", { name: "Linkward Bard" })).not.toBeVisible();
+});
+
+async function readMagicLinkToken(email: string) {
+	const databaseUrl = process.env.DATABASE_URL;
+	if (!databaseUrl) throw new Error("DATABASE_URL is required for magic-link e2e tests.");
+
+	const sql = postgres(databaseUrl, { max: 1 });
+	try {
+		const rows = await sql<{ identifier: string; value: string }[]>`
+			SELECT identifier, value
+			FROM verification
+			ORDER BY created_at DESC
+		`;
+		const row = rows.find((candidate) => JSON.parse(candidate.value).email === email);
+		if (!row) throw new Error(`Magic link token not found for ${email}.`);
+		return row.identifier;
+	} finally {
+		await sql.end();
+	}
+}


### PR DESCRIPTION
## Summary
- Add app-owned magic-link login and sign-out routes, with Better Auth verification kept behind the generated API contract.
- Add local structured-log magic-link delivery with a production guard, plus UI for signed-out and signed-in auth states.
- Transfer anonymous character ownership when a magic-link account is connected, and prevent stale character detail after sign-out.
- Update auth and quality docs, generated OpenAPI artifacts, unit/integration/e2e coverage.

## Review
- Ran two read-only code review passes with subagents.
- First review found actionable issues around route exposure, production delivery behavior, account linking order, stale UI state, and responsive layout; fixed all.
- Second review approved with no critical, important, or minor findings.

## Validation
- pnpm lint
- pnpm api:check
- pnpm test
- pnpm check:docs
- pnpm build
