### PR TITLE
Use SRD 2024 spell catalogue

### DIFF
--- a/src/domains/characters/repo/dnd-api-legacy-spell-client.test.ts
+++ b/src/domains/characters/repo/dnd-api-legacy-spell-client.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { getLegacySpellDetails } from "./dnd-api-legacy-spell-client.js";
+
+describe("getLegacySpellDetails", () => {
+	it("loads 2014 spell details for saved spells that are unavailable in SRD 2024", async () => {
+		const fetcher = vi.fn().mockResolvedValue(
+			jsonResponse({
+				index: "branding-smite",
+				name: "Branding Smite",
+				level: 2,
+				url: "/api/2014/spells/branding-smite",
+				desc: ["The weapon gleams with astral radiance as you strike."],
+				higher_level: ["The extra damage increases by 1d6."],
+				casting_time: "1 bonus action",
+				range: "Self",
+				duration: "Up to 1 minute",
+				components: ["V"],
+				school: { name: "Evocation" },
+				classes: [{ name: "Paladin" }],
+			}),
+		);
+
+		await expect(
+			getLegacySpellDetails("https://www.dnd5eapi.co", fetcher, "branding-smite", "spell"),
+		).resolves.toEqual({
+			index: "branding-smite",
+			name: "Branding Smite",
+			level: 2,
+			url: "/api/2014/spells/branding-smite",
+			source: "spell",
+			desc: ["The weapon gleams with astral radiance as you strike."],
+			higherLevel: ["The extra damage increases by 1d6."],
+			metadata: [
+				{ label: "Casting Time", value: "1 bonus action" },
+				{ label: "Range", value: "Self" },
+				{ label: "Duration", value: "Up to 1 minute" },
+				{ label: "Components", value: "V" },
+				{ label: "School", value: "Evocation" },
+				{ label: "Classes", value: "Paladin" },
+			],
+		});
+	});
+
+	it("loads 2014 feature details for already saved feature entries", async () => {
+		const fetcher = vi.fn().mockResolvedValue(
+			jsonResponse({
+				index: "divine-smite",
+				name: "Divine Smite",
+				level: 2,
+				url: "/api/2014/features/divine-smite",
+				desc: ["You can expend one spell slot to deal radiant damage."],
+				class: { name: "Paladin" },
+			}),
+		);
+
+		await expect(
+			getLegacySpellDetails("https://www.dnd5eapi.co", fetcher, "divine-smite", "feature"),
+		).resolves.toEqual({
+			index: "divine-smite",
+			name: "Divine Smite",
+			level: 2,
+			url: "/api/2014/features/divine-smite",
+			source: "feature",
+			desc: ["You can expend one spell slot to deal radiant damage."],
+			higherLevel: [],
+			metadata: [
+				{ label: "Feature Level", value: "2" },
+				{ label: "Class", value: "Paladin" },
+			],
+		});
+	});
+});
+
+function jsonResponse(body: unknown) {
+	return {
+		ok: true,
+		json: async () => body,
+	} as Response;
+}

--- a/src/domains/characters/repo/dnd-api-legacy-spell-client.ts
+++ b/src/domains/characters/repo/dnd-api-legacy-spell-client.ts
@@ -1,0 +1,110 @@
+import { z } from "zod";
+import type { DndSpellDetails, SpellEntrySource } from "../types/index.js";
+import { DndSpellDetailsSchema, SpellIndexSchema } from "../types/index.js";
+
+const DndApiReferenceSchema = z.object({
+	name: z.string(),
+});
+
+const DndApiSpellDetailResponseSchema = z.object({
+	index: z.string(),
+	name: z.string(),
+	level: z.number().int(),
+	url: z.string(),
+	desc: z.array(z.string()).min(1),
+	higher_level: z.array(z.string()).optional().default([]),
+	casting_time: z.string().optional(),
+	range: z.string().optional(),
+	duration: z.string().optional(),
+	components: z.array(z.string()).optional().default([]),
+	material: z.string().optional(),
+	school: DndApiReferenceSchema.optional(),
+	classes: z.array(DndApiReferenceSchema).optional().default([]),
+});
+
+const DndApiFeatureDetailResponseSchema = z.object({
+	index: z.string(),
+	name: z.string(),
+	level: z.number().int(),
+	url: z.string(),
+	desc: z.array(z.string()).min(1),
+	class: DndApiReferenceSchema.optional(),
+	subclass: DndApiReferenceSchema.optional(),
+});
+
+export async function getLegacySpellDetails(
+	legacyBaseUrl: string,
+	fetcher: typeof fetch,
+	spellIndex: string,
+	source: SpellEntrySource,
+): Promise<DndSpellDetails> {
+	const index = SpellIndexSchema.parse(spellIndex);
+	const resource = source === "feature" ? "features" : "spells";
+	const response = await fetcher(`${legacyBaseUrl}/api/2014/${resource}/${index}`);
+	if (!response.ok) throw new Error("Legacy D&D spell detail request failed.");
+	const schema =
+		source === "feature" ? DndApiFeatureDetailResponseSchema : DndApiSpellDetailResponseSchema;
+	return parseLegacySpellDetails(schema.parse(await response.json()), source);
+}
+
+function parseLegacySpellDetails(
+	entry:
+		| z.infer<typeof DndApiFeatureDetailResponseSchema>
+		| z.infer<typeof DndApiSpellDetailResponseSchema>,
+	source: SpellEntrySource,
+) {
+	const details =
+		source === "feature"
+			? {
+					higherLevel: [],
+					metadata: featureMetadata(entry as z.infer<typeof DndApiFeatureDetailResponseSchema>),
+				}
+			: {
+					higherLevel: (entry as z.infer<typeof DndApiSpellDetailResponseSchema>).higher_level,
+					metadata: spellMetadata(entry as z.infer<typeof DndApiSpellDetailResponseSchema>),
+				};
+
+	return DndSpellDetailsSchema.parse({
+		index: entry.index,
+		name: entry.name,
+		level: entry.level,
+		url: entry.url,
+		source,
+		desc: entry.desc,
+		...details,
+	});
+}
+
+function spellMetadata(entry: z.infer<typeof DndApiSpellDetailResponseSchema>) {
+	return [
+		metadata("Casting Time", entry.casting_time),
+		metadata("Range", entry.range),
+		metadata("Duration", entry.duration),
+		metadata("Components", formatComponents(entry.components, entry.material)),
+		metadata("School", entry.school?.name),
+		metadata("Classes", formatReferences(entry.classes)),
+	].filter((item) => item !== null);
+}
+
+function featureMetadata(entry: z.infer<typeof DndApiFeatureDetailResponseSchema>) {
+	return [
+		metadata("Feature Level", String(entry.level)),
+		metadata("Class", entry.class?.name),
+		metadata("Subclass", entry.subclass?.name),
+	].filter((item) => item !== null);
+}
+
+function metadata(label: string, value: string | undefined) {
+	const normalized = value?.trim();
+	return normalized ? { label, value: normalized } : null;
+}
+
+function formatReferences(references: Array<{ name: string }>) {
+	return references.map((reference) => reference.name).join(", ");
+}
+
+function formatComponents(components: string[], material?: string) {
+	if (components.length === 0) return "";
+	const componentText = components.join(", ");
+	return material ? `${componentText} (${material})` : componentText;
+}

--- a/src/domains/characters/repo/dnd-api-spell-client.test.ts
+++ b/src/domains/characters/repo/dnd-api-spell-client.test.ts
@@ -134,6 +134,25 @@ describe("createDndApiSpellClient", () => {
 		});
 	});
 
+	it("splits SRD 2024 spell description paragraphs", async () => {
+		const fetcher = vi.fn().mockResolvedValue(
+			jsonResponse({
+				key: "srd-2024_magic-missile",
+				name: "Magic Missile",
+				level: 1,
+				desc: "First paragraph.\n\nSecond paragraph.",
+				higher_level: "First higher-level paragraph.\n\nSecond higher-level paragraph.",
+			}),
+		);
+
+		const client = createDndApiSpellClient({ fetcher });
+
+		await expect(client.getSpellDetails("magic-missile", "spell")).resolves.toMatchObject({
+			desc: ["First paragraph.", "Second paragraph."],
+			higherLevel: ["First higher-level paragraph.", "Second higher-level paragraph."],
+		});
+	});
+
 	it("falls back to 2014 spell details when a saved spell is unavailable in SRD 2024", async () => {
 		const fetcher = vi
 			.fn()
@@ -182,6 +201,52 @@ describe("createDndApiSpellClient", () => {
 			2,
 			"https://www.dnd5eapi.co/api/2014/spells/branding-smite",
 		);
+	});
+
+	it("falls back to 2014 spell details when SRD 2024 details cannot be parsed", async () => {
+		const fetcher = vi
+			.fn()
+			.mockResolvedValueOnce(jsonResponse({ key: "srd-2024_branding-smite" }))
+			.mockResolvedValueOnce(
+				jsonResponse({
+					index: "branding-smite",
+					name: "Branding Smite",
+					level: 2,
+					url: "/api/2014/spells/branding-smite",
+					desc: ["The weapon gleams with astral radiance as you strike."],
+				}),
+			);
+
+		const client = createDndApiSpellClient({ fetcher });
+
+		await expect(client.getSpellDetails("branding-smite", "spell")).resolves.toMatchObject({
+			index: "branding-smite",
+			name: "Branding Smite",
+			url: "/api/2014/spells/branding-smite",
+		});
+	});
+
+	it("falls back to 2014 spell details when SRD 2024 detail loading fails", async () => {
+		const fetcher = vi
+			.fn()
+			.mockRejectedValueOnce(new TypeError("Failed to fetch"))
+			.mockResolvedValueOnce(
+				jsonResponse({
+					index: "branding-smite",
+					name: "Branding Smite",
+					level: 2,
+					url: "/api/2014/spells/branding-smite",
+					desc: ["The weapon gleams with astral radiance as you strike."],
+				}),
+			);
+
+		const client = createDndApiSpellClient({ fetcher });
+
+		await expect(client.getSpellDetails("branding-smite", "spell")).resolves.toMatchObject({
+			index: "branding-smite",
+			name: "Branding Smite",
+			url: "/api/2014/spells/branding-smite",
+		});
 	});
 
 	it("loads feature details with feature metadata", async () => {

--- a/src/domains/characters/repo/dnd-api-spell-client.test.ts
+++ b/src/domains/characters/repo/dnd-api-spell-client.test.ts
@@ -10,60 +10,14 @@ describe("createDndApiSpellClient", () => {
 		expect(fetcher).not.toHaveBeenCalled();
 	});
 
-	it("searches SRD spells by name and includes spell levels up to the selected slot level", async () => {
+	it("searches SRD 2024 spells by name and includes spell levels up to the selected slot level", async () => {
 		const fetcher = vi.fn().mockResolvedValue(
 			jsonResponse({
-				data: {
-					spells: [
-						{ index: "light", name: "Light", level: 0 },
-						{ index: "magic-missile", name: "Magic Missile", level: 1 },
-						{ index: "acid-arrow", name: "Acid Arrow", level: 2 },
-						{ index: "fireball", name: "Fireball", level: 3 },
-					],
-				},
-			}),
-		);
-
-		const client = createDndApiSpellClient({ fetcher });
-
-		await expect(client.searchSpells({ slotLevel: 2, query: "i" })).resolves.toEqual([
-			{
-				index: "magic-missile",
-				name: "Magic Missile",
-				level: 1,
-				url: "/api/2014/spells/magic-missile",
-				source: "spell",
-			},
-			{
-				index: "acid-arrow",
-				name: "Acid Arrow",
-				level: 2,
-				url: "/api/2014/spells/acid-arrow",
-				source: "spell",
-			},
-		]);
-		expect(fetcher).toHaveBeenCalledOnce();
-		expect(fetcher).toHaveBeenCalledWith(
-			"https://www.dnd5eapi.co/graphql",
-			expect.objectContaining({
-				method: "POST",
-				headers: { "content-type": "application/json" },
-				body: expect.stringContaining('"levels":[1,2]'),
-			}),
-		);
-	});
-
-	it("searches matching class features by name and feature level in the same request", async () => {
-		const fetcher = vi.fn().mockResolvedValue(
-			jsonResponse({
-				data: {
-					spells: [],
-					features: [
-						{ index: "divine-smite", name: "Divine Smite", level: 2 },
-						{ index: "improved-divine-smite", name: "Improved Divine Smite", level: 11 },
-						{ index: "lay-on-hands", name: "Lay on Hands", level: 1 },
-					],
-				},
+				results: [
+					{ key: "srd-2024_divine-smite", name: "Divine Smite", level: 1 },
+					{ key: "srd-2024_searing-smite", name: "Searing Smite", level: 1 },
+					{ key: "srd-2024_shining-smite", name: "Shining Smite", level: 2 },
+				],
 			}),
 		);
 
@@ -73,36 +27,31 @@ describe("createDndApiSpellClient", () => {
 			{
 				index: "divine-smite",
 				name: "Divine Smite",
-				level: 2,
-				url: "/api/2014/features/divine-smite",
-				source: "feature",
+				level: 1,
+				url: "/api/2024/spells/divine-smite",
+				source: "spell",
 			},
 			{
-				index: "improved-divine-smite",
-				name: "Improved Divine Smite",
-				level: 11,
-				url: "/api/2014/features/improved-divine-smite",
-				source: "feature",
+				index: "searing-smite",
+				name: "Searing Smite",
+				level: 1,
+				url: "/api/2024/spells/searing-smite",
+				source: "spell",
 			},
 		]);
 		expect(fetcher).toHaveBeenCalledOnce();
 		expect(fetcher).toHaveBeenCalledWith(
-			"https://www.dnd5eapi.co/graphql",
-			expect.objectContaining({
-				method: "POST",
-				body: expect.stringContaining('"includeFeatures":true'),
-			}),
+			"https://api.open5e.com/v2/spells/?name__icontains=smite&document__key__in=srd-2024&level__lte=1&fields=key,name,level",
 		);
 	});
 
-	it("loads a canonical spell by index before saving", async () => {
+	it("loads a canonical SRD 2024 spell by index before saving", async () => {
 		const fetcher = vi.fn().mockResolvedValue(
 			jsonResponse({
-				index: "magic-missile",
+				key: "srd-2024_magic-missile",
 				name: "Magic Missile",
 				level: 1,
-				url: "/api/2014/spells/magic-missile",
-				desc: ["You create three glowing darts of magical force."],
+				desc: "You create three glowing darts of magical force.",
 				higher_level: [],
 			}),
 		);
@@ -113,10 +62,12 @@ describe("createDndApiSpellClient", () => {
 			index: "magic-missile",
 			name: "Magic Missile",
 			level: 1,
-			url: "/api/2014/spells/magic-missile",
+			url: "/api/2024/spells/magic-missile",
 			source: "spell",
 		});
-		expect(fetcher).toHaveBeenCalledWith("https://www.dnd5eapi.co/api/2014/spells/magic-missile");
+		expect(fetcher).toHaveBeenCalledWith(
+			"https://api.open5e.com/v2/spells/srd-2024_magic-missile/?fields=key,name,level,desc,higher_level,casting_time,range_text,duration,verbal,somatic,material,material_specified,school,classes",
+		);
 	});
 
 	it("loads a canonical feature by index before saving", async () => {
@@ -142,19 +93,21 @@ describe("createDndApiSpellClient", () => {
 		expect(fetcher).toHaveBeenCalledWith("https://www.dnd5eapi.co/api/2014/features/lay-on-hands");
 	});
 
-	it("loads spell details with description, higher-level text, and metadata", async () => {
+	it("loads SRD 2024 spell details with description, higher-level text, and metadata", async () => {
 		const fetcher = vi.fn().mockResolvedValue(
 			jsonResponse({
-				index: "magic-missile",
+				key: "srd-2024_magic-missile",
 				name: "Magic Missile",
 				level: 1,
-				url: "/api/2014/spells/magic-missile",
-				desc: ["You create three glowing darts of magical force."],
-				higher_level: ["One more dart is created for each slot level above 1st."],
-				casting_time: "1 action",
-				range: "120 feet",
-				duration: "Instantaneous",
-				components: ["V", "S"],
+				desc: "You create three glowing darts of magical force.",
+				higher_level: "The spell creates one more dart for each spell slot level above 1.",
+				casting_time: "action",
+				range_text: "120 feet",
+				duration: "instantaneous",
+				verbal: true,
+				somatic: true,
+				material: false,
+				material_specified: "",
 				school: { name: "Evocation" },
 				classes: [{ name: "Wizard" }, { name: "Sorcerer" }],
 			}),
@@ -166,19 +119,69 @@ describe("createDndApiSpellClient", () => {
 			index: "magic-missile",
 			name: "Magic Missile",
 			level: 1,
-			url: "/api/2014/spells/magic-missile",
+			url: "/api/2024/spells/magic-missile",
 			source: "spell",
 			desc: ["You create three glowing darts of magical force."],
-			higherLevel: ["One more dart is created for each slot level above 1st."],
+			higherLevel: ["The spell creates one more dart for each spell slot level above 1."],
 			metadata: [
-				{ label: "Casting Time", value: "1 action" },
+				{ label: "Casting Time", value: "action" },
 				{ label: "Range", value: "120 feet" },
-				{ label: "Duration", value: "Instantaneous" },
+				{ label: "Duration", value: "instantaneous" },
 				{ label: "Components", value: "V, S" },
 				{ label: "School", value: "Evocation" },
 				{ label: "Classes", value: "Wizard, Sorcerer" },
 			],
 		});
+	});
+
+	it("falls back to 2014 spell details when a saved spell is unavailable in SRD 2024", async () => {
+		const fetcher = vi
+			.fn()
+			.mockResolvedValueOnce({ ok: false } as Response)
+			.mockResolvedValueOnce(
+				jsonResponse({
+					index: "branding-smite",
+					name: "Branding Smite",
+					level: 2,
+					url: "/api/2014/spells/branding-smite",
+					desc: ["The weapon gleams with astral radiance as you strike."],
+					higher_level: ["The extra damage increases by 1d6."],
+					casting_time: "1 bonus action",
+					range: "Self",
+					duration: "Up to 1 minute",
+					components: ["V"],
+					school: { name: "Evocation" },
+					classes: [{ name: "Paladin" }],
+				}),
+			);
+
+		const client = createDndApiSpellClient({ fetcher });
+
+		await expect(client.getSpellDetails("branding-smite", "spell")).resolves.toEqual({
+			index: "branding-smite",
+			name: "Branding Smite",
+			level: 2,
+			url: "/api/2014/spells/branding-smite",
+			source: "spell",
+			desc: ["The weapon gleams with astral radiance as you strike."],
+			higherLevel: ["The extra damage increases by 1d6."],
+			metadata: [
+				{ label: "Casting Time", value: "1 bonus action" },
+				{ label: "Range", value: "Self" },
+				{ label: "Duration", value: "Up to 1 minute" },
+				{ label: "Components", value: "V" },
+				{ label: "School", value: "Evocation" },
+				{ label: "Classes", value: "Paladin" },
+			],
+		});
+		expect(fetcher).toHaveBeenNthCalledWith(
+			1,
+			"https://api.open5e.com/v2/spells/srd-2024_branding-smite/?fields=key,name,level,desc,higher_level,casting_time,range_text,duration,verbal,somatic,material,material_specified,school,classes",
+		);
+		expect(fetcher).toHaveBeenNthCalledWith(
+			2,
+			"https://www.dnd5eapi.co/api/2014/spells/branding-smite",
+		);
 	});
 
 	it("loads feature details with feature metadata", async () => {

--- a/src/domains/characters/repo/dnd-api-spell-client.ts
+++ b/src/domains/characters/repo/dnd-api-spell-client.ts
@@ -5,75 +5,47 @@ import {
 	DndSpellSearchResultSchema,
 	SpellIndexSchema,
 } from "../types/index.js";
+import { getLegacySpellDetails } from "./dnd-api-legacy-spell-client.js";
 
-const DND_API_REST_BASE_URL = "https://www.dnd5eapi.co";
+const OPEN5E_API_BASE_URL = "https://api.open5e.com/v2";
+const DND_API_2014_REST_BASE_URL = "https://www.dnd5eapi.co";
+const OPEN5E_SRD_2024_DOCUMENT_KEY = "srd-2024";
+const OPEN5E_DETAIL_FIELDS =
+	"key,name,level,desc,higher_level,casting_time,range_text,duration,verbal,somatic,material,material_specified,school,classes";
 
 const DndApiReferenceSchema = z.object({
 	name: z.string(),
 });
 
-const DndApiSpellDetailResponseSchema = z.object({
-	index: z.string(),
+const Open5eSearchResponseSchema = z.object({
+	results: z.array(
+		z.object({
+			key: z.string(),
+			name: z.string(),
+			level: z.number().int(),
+		}),
+	),
+});
+
+const Open5eSpellDetailResponseSchema = z.object({
+	key: z.string(),
 	name: z.string(),
 	level: z.number().int(),
-	url: z.string(),
-	desc: z.array(z.string()).min(1),
-	higher_level: z.array(z.string()).optional().default([]),
+	desc: z.union([z.string(), z.array(z.string()).min(1)]),
+	higher_level: z
+		.union([z.string(), z.array(z.string())])
+		.optional()
+		.default(""),
 	casting_time: z.string().optional(),
-	range: z.string().optional(),
+	range_text: z.string().optional(),
 	duration: z.string().optional(),
-	components: z.array(z.string()).optional().default([]),
-	material: z.string().optional(),
+	verbal: z.boolean().optional().default(false),
+	somatic: z.boolean().optional().default(false),
+	material: z.boolean().optional().default(false),
+	material_specified: z.string().optional(),
 	school: DndApiReferenceSchema.optional(),
 	classes: z.array(DndApiReferenceSchema).optional().default([]),
 });
-
-const DndApiFeatureDetailResponseSchema = z.object({
-	index: z.string(),
-	name: z.string(),
-	level: z.number().int(),
-	url: z.string(),
-	desc: z.array(z.string()).min(1),
-	class: DndApiReferenceSchema.optional(),
-	subclass: DndApiReferenceSchema.optional(),
-});
-
-const DndApiSearchResponseSchema = z.object({
-	data: z.object({
-		spells: z.array(
-			z.object({
-				index: z.string(),
-				name: z.string(),
-				level: z.number().int(),
-			}),
-		),
-		features: z
-			.array(
-				z.object({
-					index: z.string(),
-					name: z.string(),
-					level: z.number().int(),
-				}),
-			)
-			.optional()
-			.default([]),
-	}),
-});
-
-const SEARCH_SPELL_ENTRIES = `
-	query SearchSpellEntries($name: String!, $levels: [Int!], $includeFeatures: Boolean!) {
-		spells(name: $name, level: $levels, limit: 50) {
-			index
-			name
-			level
-		}
-		features(name: $name, limit: 20) @include(if: $includeFeatures) {
-			index
-			name
-			level
-		}
-	}
-`;
 
 export interface SearchSpellsInput {
 	slotLevel: number;
@@ -87,8 +59,8 @@ export interface DndApiSpellClient {
 }
 
 export interface DndApiSpellClientOptions {
-	baseUrl?: string;
-	graphqlEndpoint?: string;
+	open5eBaseUrl?: string;
+	legacyBaseUrl?: string;
 	fetcher?: typeof fetch;
 }
 
@@ -100,8 +72,8 @@ export class DndApiSpellClientError extends Error {
 }
 
 export function createDndApiSpellClient(options: DndApiSpellClientOptions = {}): DndApiSpellClient {
-	const baseUrl = options.baseUrl ?? DND_API_REST_BASE_URL;
-	const graphqlEndpoint = options.graphqlEndpoint ?? `${baseUrl}/graphql`;
+	const open5eBaseUrl = trimTrailingSlash(options.open5eBaseUrl ?? OPEN5E_API_BASE_URL);
+	const legacyBaseUrl = trimTrailingSlash(options.legacyBaseUrl ?? DND_API_2014_REST_BASE_URL);
 	const fetcher = options.fetcher ?? fetch;
 
 	return {
@@ -109,13 +81,9 @@ export function createDndApiSpellClient(options: DndApiSpellClientOptions = {}):
 			try {
 				const query = input.query.trim().toLowerCase();
 				if (query.length === 0) return [];
-				const { spells, features } = await searchEntries(
-					graphqlEndpoint,
-					fetcher,
-					input.slotLevel,
-					query,
+				return (await searchEntries(open5eBaseUrl, fetcher, input.slotLevel, query)).sort(
+					compareSearchResults,
 				);
-				return [...spells, ...features].sort(compareSearchResults);
 			} catch (error) {
 				if (error instanceof DndApiSpellClientError) throw error;
 				throw new DndApiSpellClientError();
@@ -124,7 +92,14 @@ export function createDndApiSpellClient(options: DndApiSpellClientOptions = {}):
 
 		async findSpell(spellIndex, source = "spell") {
 			try {
-				return parseSearchResult(await fetchDetail(baseUrl, fetcher, spellIndex, source), source);
+				const details = await getDetails(open5eBaseUrl, legacyBaseUrl, fetcher, spellIndex, source);
+				return DndSpellSearchResultSchema.parse({
+					index: details.index,
+					name: details.name,
+					level: details.level,
+					url: details.url,
+					source: details.source,
+				});
 			} catch (error) {
 				if (error instanceof DndApiSpellClientError) throw error;
 				throw new DndApiSpellClientError();
@@ -133,8 +108,7 @@ export function createDndApiSpellClient(options: DndApiSpellClientOptions = {}):
 
 		async getSpellDetails(spellIndex, source = "spell") {
 			try {
-				const detail = await fetchDetail(baseUrl, fetcher, spellIndex, source);
-				return parseSpellDetails(detail, source);
+				return getDetails(open5eBaseUrl, legacyBaseUrl, fetcher, spellIndex, source);
 			} catch (error) {
 				if (error instanceof DndApiSpellClientError) throw error;
 				throw new DndApiSpellClientError();
@@ -144,119 +118,87 @@ export function createDndApiSpellClient(options: DndApiSpellClientOptions = {}):
 }
 
 async function searchEntries(
-	graphqlEndpoint: string,
+	open5eBaseUrl: string,
 	fetcher: typeof fetch,
 	slotLevel: number,
 	query: string,
 ) {
-	const response = await fetcher(graphqlEndpoint, {
-		method: "POST",
-		headers: { "content-type": "application/json" },
-		body: JSON.stringify({
-			query: SEARCH_SPELL_ENTRIES,
-			variables: {
-				name: query,
-				levels: spellLevelsUpTo(slotLevel),
-				includeFeatures: query.length >= 3,
-			},
-		}),
-	});
+	const response = await fetcher(searchUrl(open5eBaseUrl, slotLevel, query));
 	if (!response.ok) throw new DndApiSpellClientError();
 
-	const parsed = DndApiSearchResponseSchema.parse(await response.json());
-	const spells = parsed.data.spells
+	const parsed = Open5eSearchResponseSchema.parse(await response.json());
+	return parsed.results
 		.filter((spell) => spell.level >= 1 && spell.level <= slotLevel)
-		.filter((spell) => query.length === 0 || matchesName(spell.name, query))
-		.map((spell) => parseGraphqlSearchResult(spell, "spell"));
-	const features = parsed.data.features
-		.filter((feature) => query.length >= 3 && matchesName(feature.name, query))
-		.map((feature) => parseGraphqlSearchResult(feature, "feature"));
-
-	return { spells, features };
+		.filter((spell) => matchesName(spell.name, query))
+		.map(parseOpen5eSearchResult);
 }
 
-function parseSearchResult(
-	entry: { index: string; level: number; name: string; url: string },
-	source: SpellEntrySource,
-) {
-	return DndSpellSearchResultSchema.parse({ ...entry, source });
+function parseOpen5eSearchResult(entry: { key: string; level: number; name: string }) {
+	const index = spellIndexFromOpen5eKey(entry.key);
+	return DndSpellSearchResultSchema.parse({
+		index,
+		name: entry.name,
+		level: entry.level,
+		url: spellApiUrl(index, "spell", "2024"),
+		source: "spell",
+	});
 }
 
-function parseGraphqlSearchResult(
-	entry: { index: string; level: number; name: string },
-	source: SpellEntrySource,
-) {
-	return parseSearchResult({ ...entry, url: spellApiUrl(entry.index, source) }, source);
-}
-
-function spellLevelsUpTo(slotLevel: number) {
-	return Array.from({ length: slotLevel }, (_, index) => index + 1);
-}
-
-function spellApiUrl(index: string, source: SpellEntrySource) {
+function spellApiUrl(index: string, source: SpellEntrySource, version: "2014" | "2024") {
 	const resource = source === "feature" ? "features" : "spells";
-	return `/api/2014/${resource}/${index}`;
+	return `/api/${version}/${resource}/${index}`;
 }
 
-async function fetchDetail(
-	baseUrl: string,
+async function fetchOpen5eDetail(open5eBaseUrl: string, fetcher: typeof fetch, spellIndex: string) {
+	const index = SpellIndexSchema.parse(spellIndex);
+	const response = await fetcher(
+		`${open5eBaseUrl}/spells/${open5eSpellKey(index)}/?fields=${OPEN5E_DETAIL_FIELDS}`,
+	);
+	if (!response.ok) throw new DndApiSpellClientError();
+	return Open5eSpellDetailResponseSchema.parse(await response.json());
+}
+
+async function getDetails(
+	open5eBaseUrl: string,
+	legacyBaseUrl: string,
 	fetcher: typeof fetch,
 	spellIndex: string,
 	source: SpellEntrySource,
 ) {
-	const index = SpellIndexSchema.parse(spellIndex);
-	const resource = source === "feature" ? "features" : "spells";
-	const response = await fetcher(`${baseUrl}/api/2014/${resource}/${index}`);
-	if (!response.ok) throw new DndApiSpellClientError();
-	const schema =
-		source === "feature" ? DndApiFeatureDetailResponseSchema : DndApiSpellDetailResponseSchema;
-	return schema.parse(await response.json());
+	if (source === "feature") {
+		return getLegacySpellDetails(legacyBaseUrl, fetcher, spellIndex, source);
+	}
+
+	try {
+		return parseOpen5eSpellDetails(await fetchOpen5eDetail(open5eBaseUrl, fetcher, spellIndex));
+	} catch (error) {
+		if (!(error instanceof DndApiSpellClientError)) throw error;
+		return getLegacySpellDetails(legacyBaseUrl, fetcher, spellIndex, source);
+	}
 }
 
-function parseSpellDetails(
-	entry:
-		| z.infer<typeof DndApiFeatureDetailResponseSchema>
-		| z.infer<typeof DndApiSpellDetailResponseSchema>,
-	source: SpellEntrySource,
-) {
-	const details =
-		source === "feature"
-			? {
-					higherLevel: [],
-					metadata: featureMetadata(entry as z.infer<typeof DndApiFeatureDetailResponseSchema>),
-				}
-			: {
-					higherLevel: (entry as z.infer<typeof DndApiSpellDetailResponseSchema>).higher_level,
-					metadata: spellMetadata(entry as z.infer<typeof DndApiSpellDetailResponseSchema>),
-				};
-
+function parseOpen5eSpellDetails(entry: z.infer<typeof Open5eSpellDetailResponseSchema>) {
+	const index = spellIndexFromOpen5eKey(entry.key);
 	return DndSpellDetailsSchema.parse({
-		index: entry.index,
+		index,
 		name: entry.name,
 		level: entry.level,
-		url: entry.url,
-		source,
-		desc: entry.desc,
-		...details,
+		url: spellApiUrl(index, "spell", "2024"),
+		source: "spell",
+		desc: textArray(entry.desc),
+		higherLevel: textArray(entry.higher_level),
+		metadata: open5eSpellMetadata(entry),
 	});
 }
 
-function spellMetadata(entry: z.infer<typeof DndApiSpellDetailResponseSchema>) {
+function open5eSpellMetadata(entry: z.infer<typeof Open5eSpellDetailResponseSchema>) {
 	return [
 		metadata("Casting Time", entry.casting_time),
-		metadata("Range", entry.range),
+		metadata("Range", entry.range_text),
 		metadata("Duration", entry.duration),
-		metadata("Components", formatComponents(entry.components, entry.material)),
+		metadata("Components", formatOpen5eComponents(entry)),
 		metadata("School", entry.school?.name),
 		metadata("Classes", formatReferences(entry.classes)),
-	].filter((item) => item !== null);
-}
-
-function featureMetadata(entry: z.infer<typeof DndApiFeatureDetailResponseSchema>) {
-	return [
-		metadata("Feature Level", String(entry.level)),
-		metadata("Class", entry.class?.name),
-		metadata("Subclass", entry.subclass?.name),
 	].filter((item) => item !== null);
 }
 
@@ -275,10 +217,42 @@ function formatComponents(components: string[], material?: string) {
 	return material ? `${componentText} (${material})` : componentText;
 }
 
+function formatOpen5eComponents(entry: z.infer<typeof Open5eSpellDetailResponseSchema>) {
+	const components = [
+		entry.verbal ? "V" : null,
+		entry.somatic ? "S" : null,
+		entry.material ? "M" : null,
+	].filter((component) => component !== null);
+	return formatComponents(components, entry.material_specified);
+}
+
 function matchesName(name: string, query: string) {
 	return name.toLowerCase().includes(query);
 }
 
 function compareSearchResults(left: DndSpellSearchResult, right: DndSpellSearchResult) {
 	return left.level - right.level || left.name.localeCompare(right.name);
+}
+
+function searchUrl(open5eBaseUrl: string, slotLevel: number, query: string) {
+	return `${open5eBaseUrl}/spells/?name__icontains=${encodeURIComponent(query)}&document__key__in=${OPEN5E_SRD_2024_DOCUMENT_KEY}&level__lte=${slotLevel}&fields=key,name,level`;
+}
+
+function open5eSpellKey(index: string) {
+	return `${OPEN5E_SRD_2024_DOCUMENT_KEY}_${index}`;
+}
+
+function spellIndexFromOpen5eKey(key: string) {
+	const prefix = `${OPEN5E_SRD_2024_DOCUMENT_KEY}_`;
+	return SpellIndexSchema.parse(key.startsWith(prefix) ? key.slice(prefix.length) : key);
+}
+
+function textArray(value: string | string[]) {
+	if (Array.isArray(value)) return value.map((item) => item.trim()).filter(Boolean);
+	const normalized = value.trim();
+	return normalized ? [normalized] : [];
+}
+
+function trimTrailingSlash(value: string) {
+	return value.replace(/\/+$/, "");
 }

--- a/src/domains/characters/repo/dnd-api-spell-client.ts
+++ b/src/domains/characters/repo/dnd-api-spell-client.ts
@@ -171,8 +171,7 @@ async function getDetails(
 
 	try {
 		return parseOpen5eSpellDetails(await fetchOpen5eDetail(open5eBaseUrl, fetcher, spellIndex));
-	} catch (error) {
-		if (!(error instanceof DndApiSpellClientError)) throw error;
+	} catch {
 		return getLegacySpellDetails(legacyBaseUrl, fetcher, spellIndex, source);
 	}
 }
@@ -218,11 +217,10 @@ function formatComponents(components: string[], material?: string) {
 }
 
 function formatOpen5eComponents(entry: z.infer<typeof Open5eSpellDetailResponseSchema>) {
-	const components = [
-		entry.verbal ? "V" : null,
-		entry.somatic ? "S" : null,
-		entry.material ? "M" : null,
-	].filter((component) => component !== null);
+	const components: string[] = [];
+	if (entry.verbal) components.push("V");
+	if (entry.somatic) components.push("S");
+	if (entry.material) components.push("M");
 	return formatComponents(components, entry.material_specified);
 }
 
@@ -249,8 +247,10 @@ function spellIndexFromOpen5eKey(key: string) {
 
 function textArray(value: string | string[]) {
 	if (Array.isArray(value)) return value.map((item) => item.trim()).filter(Boolean);
-	const normalized = value.trim();
-	return normalized ? [normalized] : [];
+	return value
+		.split(/\r?\n\r?\n/)
+		.map((item) => item.trim())
+		.filter(Boolean);
 }
 
 function trimTrailingSlash(value: string) {

--- a/src/domains/characters/types/character.test.ts
+++ b/src/domains/characters/types/character.test.ts
@@ -109,7 +109,7 @@ describe("Character spell schemas", () => {
 					index: "magic-missile",
 					name: "Magic Missile",
 					level: 1,
-					url: "/api/2014/spells/magic-missile",
+					url: "/api/2024/spells/magic-missile",
 					source: "spell",
 				},
 				{

--- a/src/domains/characters/types/character.ts
+++ b/src/domains/characters/types/character.ts
@@ -46,7 +46,7 @@ export const SpellApiUrlSchema = z
 	.string()
 	.min(1)
 	.max(240)
-	.regex(/^\/api\/2014\/(?:features|spells)\/[a-z0-9-]+$/);
+	.regex(/^\/api\/(?:2014|2024)\/(?:features|spells)\/[a-z0-9-]+$/);
 export const CharacterSpellIdSchema = z.string().uuid();
 export type CharacterSpellId = z.infer<typeof CharacterSpellIdSchema>;
 

--- a/src/generated/openapi.generated.json
+++ b/src/generated/openapi.generated.json
@@ -2132,7 +2132,7 @@
 														"type": "string",
 														"minLength": 1,
 														"maxLength": 240,
-														"pattern": "^\\/api\\/2014\\/(?:features|spells)\\/[a-z0-9-]+$"
+														"pattern": "^\\/api\\/(?:2014|2024)\\/(?:features|spells)\\/[a-z0-9-]+$"
 													},
 													"source": {
 														"default": "spell",
@@ -2284,7 +2284,7 @@
 														"type": "string",
 														"minLength": 1,
 														"maxLength": 240,
-														"pattern": "^\\/api\\/2014\\/(?:features|spells)\\/[a-z0-9-]+$"
+														"pattern": "^\\/api\\/(?:2014|2024)\\/(?:features|spells)\\/[a-z0-9-]+$"
 													},
 													"source": {
 														"default": "spell",
@@ -2447,7 +2447,7 @@
 													"type": "string",
 													"minLength": 1,
 													"maxLength": 240,
-													"pattern": "^\\/api\\/2014\\/(?:features|spells)\\/[a-z0-9-]+$"
+													"pattern": "^\\/api\\/(?:2014|2024)\\/(?:features|spells)\\/[a-z0-9-]+$"
 												},
 												"source": {
 													"default": "spell",
@@ -2644,7 +2644,7 @@
 														"type": "string",
 														"minLength": 1,
 														"maxLength": 240,
-														"pattern": "^\\/api\\/2014\\/(?:features|spells)\\/[a-z0-9-]+$"
+														"pattern": "^\\/api\\/(?:2014|2024)\\/(?:features|spells)\\/[a-z0-9-]+$"
 													},
 													"source": {
 														"default": "spell",

--- a/tests/e2e/character-health-flow.spec.ts
+++ b/tests/e2e/character-health-flow.spec.ts
@@ -88,10 +88,10 @@ test("configures spell slots and tracks spell usage on detail", async ({ page })
 	await page.getByRole("button", { name: /^Divine Smite\b/ }).click();
 	await expect(page.getByRole("dialog", { name: "Add spell to 3rd-level" })).toBeHidden();
 	await expect(page.getByRole("button", { name: "View Divine Smite details" })).toBeVisible();
-	await expect(page.getByText("2nd-level feature")).toBeVisible();
+	await expect(page.getByText("1st-level spell")).toBeVisible();
 	await page.getByRole("button", { name: "View Divine Smite details" }).click();
 	await expect(page.getByRole("dialog", { name: "Divine Smite" })).toBeVisible();
-	await expect(page.getByText("Feature 2nd-level")).toBeVisible();
+	await expect(page.getByText("Spell 1st-level")).toBeVisible();
 	await expect(page.getByText(/radiant damage/i)).toBeVisible();
 	await page.keyboard.press("Escape");
 	await expect(page.getByRole("dialog", { name: "Divine Smite" })).toBeHidden();


### PR DESCRIPTION
## Summary
- switch default spell search/details to Open5e v2 SRD 2024 data
- keep a 2014 D&D API fallback for saved spell and feature details
- update spell URL validation, generated OpenAPI, and e2e expectations for Divine Smite as a 2024 spell

## Validation
- pnpm lint
- pnpm api:check
- pnpm test:unit
- pnpm test
- pnpm check:docs
- pnpm build

## Notes
- Existing unrelated local docs changes are intentionally not included in this PR.