### PR TITLE
Add cantrips and features spell section

### DIFF
--- a/docs/quality.md
+++ b/docs/quality.md
@@ -14,7 +14,7 @@ Track the health of each domain and architectural layer. Update this when you im
 
 | Domain | Types | Config | Repo | Service | Runtime | UI | Overall | Notes |
 |--------|-------|--------|------|---------|---------|----|---------|----|
-| characters | B | B | B | B | B | B | B | Character create/list/detail, detail-page level editing, health tracking, spell slot tracking, mobile-safe editable input sizing, add/remove-spell flows, and saved spell details have unit, integration, route, generated-client, and e2e coverage |
+| characters | B | B | B | B | B | B | B | Character create/list/detail, detail-page level editing, health tracking, spell slot tracking, mobile-safe editable input sizing, add/remove-spell flows, cantrip and feature spell-list entries, and saved spell details have unit, integration, route, generated-client, and e2e coverage |
 
 ## Cross-Cutting
 

--- a/migrations/0008_character_spells_non_slot.sql
+++ b/migrations/0008_character_spells_non_slot.sql
@@ -1,0 +1,13 @@
+ALTER TABLE character_spells
+DROP CONSTRAINT IF EXISTS character_spells_slot_level_check;
+
+ALTER TABLE character_spells
+DROP CONSTRAINT IF EXISTS character_spells_spell_level_check;
+
+ALTER TABLE character_spells
+ADD CONSTRAINT character_spells_slot_level_check
+CHECK (slot_level BETWEEN 0 AND 9);
+
+ALTER TABLE character_spells
+ADD CONSTRAINT character_spells_spell_level_check
+CHECK (spell_level BETWEEN 0 AND 20);

--- a/src/domains/characters/repo/character-spell-repository.integration.test.ts
+++ b/src/domains/characters/repo/character-spell-repository.integration.test.ts
@@ -100,7 +100,7 @@ describe("createCharacterSpellRepository", () => {
 		).resolves.toBeNull();
 	});
 
-	it("persists high-level class features saved under a spell slot", async () => {
+	it("persists high-level class features saved in the non-slot bucket", async () => {
 		const userId = await createUser();
 		const character = await createCharacterRepository().createCharacter({
 			userId,
@@ -112,7 +112,7 @@ describe("createCharacterSpellRepository", () => {
 		const repository = createCharacterSpellRepository();
 
 		const saved = await repository.saveCharacterSpell(userId, character.id, {
-			slotLevel: 1,
+			slotLevel: 0,
 			source: "feature",
 			spellIndex: "improved-divine-smite",
 			name: "Improved Divine Smite",
@@ -122,11 +122,64 @@ describe("createCharacterSpellRepository", () => {
 
 		expect(saved?.spells).toEqual([
 			expect.objectContaining({
-				slotLevel: 1,
+				slotLevel: 0,
 				spellIndex: "improved-divine-smite",
 				name: "Improved Divine Smite",
 				level: 11,
 				source: "feature",
+			}),
+		]);
+	});
+
+	it("persists cantrips and features in the non-slot bucket before numbered spells", async () => {
+		const userId = await createUser();
+		const character = await createCharacterRepository().createCharacter({
+			userId,
+			name: "Aurelia",
+			className: "Paladin",
+			level: 7,
+			maxHp: 58,
+		});
+		const repository = createCharacterSpellRepository();
+
+		await repository.saveCharacterSpell(userId, character.id, {
+			slotLevel: 3,
+			source: "spell",
+			spellIndex: "magic-missile",
+			name: "Magic Missile",
+			level: 1,
+			url: "/api/2014/spells/magic-missile",
+		});
+		await repository.saveCharacterSpell(userId, character.id, {
+			slotLevel: 0,
+			source: "spell",
+			spellIndex: "light",
+			name: "Light",
+			level: 0,
+			url: "/api/2014/spells/light",
+		});
+		await repository.saveCharacterSpell(userId, character.id, {
+			slotLevel: 0,
+			source: "feature",
+			spellIndex: "lay-on-hands",
+			name: "Lay on Hands",
+			level: 1,
+			url: "/api/2014/features/lay-on-hands",
+		});
+
+		await expect(repository.listCharacterSpells(userId, character.id)).resolves.toEqual([
+			expect.objectContaining({ slotLevel: 0, spellIndex: "light", level: 0, source: "spell" }),
+			expect.objectContaining({
+				slotLevel: 0,
+				spellIndex: "lay-on-hands",
+				level: 1,
+				source: "feature",
+			}),
+			expect.objectContaining({
+				slotLevel: 3,
+				spellIndex: "magic-missile",
+				level: 1,
+				source: "spell",
 			}),
 		]);
 	});

--- a/src/domains/characters/repo/dnd-api-legacy-spell-client.ts
+++ b/src/domains/characters/repo/dnd-api-legacy-spell-client.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
-import type { DndSpellDetails, SpellEntrySource } from "../types/index.js";
-import { DndSpellDetailsSchema, SpellIndexSchema } from "../types/index.js";
+import type { DndSpellDetails, DndSpellSearchResult, SpellEntrySource } from "../types/index.js";
+import {
+	DndSpellDetailsSchema,
+	DndSpellSearchResultSchema,
+	SpellIndexSchema,
+} from "../types/index.js";
 
 const DndApiReferenceSchema = z.object({
 	name: z.string(),
@@ -31,6 +35,43 @@ const DndApiFeatureDetailResponseSchema = z.object({
 	class: DndApiReferenceSchema.optional(),
 	subclass: DndApiReferenceSchema.optional(),
 });
+
+const DndApiFeatureSearchResponseSchema = z.object({
+	results: z.array(
+		z.object({
+			index: z.string(),
+			name: z.string(),
+		}),
+	),
+});
+
+export async function searchLegacyFeatures(
+	legacyBaseUrl: string,
+	fetcher: typeof fetch,
+	query: string,
+): Promise<DndSpellSearchResult[]> {
+	const response = await fetcher(
+		`${legacyBaseUrl}/api/2014/features?name=${encodeURIComponent(query)}`,
+	);
+	if (!response.ok) throw new Error("Legacy D&D feature search request failed.");
+
+	const parsed = DndApiFeatureSearchResponseSchema.parse(await response.json());
+	const details = await Promise.all(
+		parsed.results
+			.filter((feature) => matchesName(feature.name, query))
+			.map((feature) => getLegacySpellDetails(legacyBaseUrl, fetcher, feature.index, "feature")),
+	);
+
+	return details.map((feature) =>
+		DndSpellSearchResultSchema.parse({
+			index: feature.index,
+			name: feature.name,
+			level: feature.level,
+			url: feature.url,
+			source: "feature",
+		}),
+	);
+}
 
 export async function getLegacySpellDetails(
 	legacyBaseUrl: string,
@@ -107,4 +148,8 @@ function formatComponents(components: string[], material?: string) {
 	if (components.length === 0) return "";
 	const componentText = components.join(", ");
 	return material ? `${componentText} (${material})` : componentText;
+}
+
+function matchesName(name: string, query: string) {
+	return name.toLowerCase().includes(query);
 }

--- a/src/domains/characters/repo/dnd-api-spell-client-search.test.ts
+++ b/src/domains/characters/repo/dnd-api-spell-client-search.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDndApiSpellClient } from "./dnd-api-spell-client.js";
+
+describe("createDndApiSpellClient search", () => {
+	it("returns no search results without calling the API for an empty query", async () => {
+		const fetcher = vi.fn();
+		const client = createDndApiSpellClient({ fetcher });
+
+		await expect(client.searchSpells({ slotLevel: 3, query: " " })).resolves.toEqual([]);
+		expect(fetcher).not.toHaveBeenCalled();
+	});
+
+	it("searches SRD 2024 spells by name and includes spell levels up to the selected slot level", async () => {
+		const fetcher = vi.fn().mockResolvedValue(
+			jsonResponse({
+				results: [
+					{ key: "srd-2024_divine-smite", name: "Divine Smite", level: 1 },
+					{ key: "srd-2024_searing-smite", name: "Searing Smite", level: 1 },
+					{ key: "srd-2024_shining-smite", name: "Shining Smite", level: 2 },
+				],
+			}),
+		);
+
+		const client = createDndApiSpellClient({ fetcher });
+
+		await expect(client.searchSpells({ slotLevel: 1, query: "smite" })).resolves.toEqual([
+			{
+				index: "divine-smite",
+				name: "Divine Smite",
+				level: 1,
+				url: "/api/2024/spells/divine-smite",
+				source: "spell",
+			},
+			{
+				index: "searing-smite",
+				name: "Searing Smite",
+				level: 1,
+				url: "/api/2024/spells/searing-smite",
+				source: "spell",
+			},
+		]);
+		expect(fetcher).toHaveBeenCalledOnce();
+		expect(fetcher).toHaveBeenCalledWith(
+			"https://api.open5e.com/v2/spells/?name__icontains=smite&document__key__in=srd-2024&level__lte=1&fields=key,name,level",
+		);
+	});
+
+	it("searches SRD 2024 cantrips and 2014 features in the non-slot bucket", async () => {
+		const fetcher = vi
+			.fn()
+			.mockResolvedValueOnce(
+				jsonResponse({
+					results: [
+						{ key: "srd-2024_dancing-lights", name: "Dancing Lights", level: 0 },
+						{ key: "srd-2024_light", name: "Light", level: 0 },
+						{ key: "srd-2024_magic-missile", name: "Magic Missile", level: 1 },
+					],
+				}),
+			)
+			.mockResolvedValueOnce(
+				jsonResponse({
+					results: [{ index: "lay-on-hands", name: "Lay on Hands" }],
+				}),
+			)
+			.mockResolvedValueOnce(
+				jsonResponse({
+					index: "lay-on-hands",
+					name: "Lay on Hands",
+					level: 1,
+					url: "/api/2014/features/lay-on-hands",
+					desc: ["Your blessed touch can heal wounds."],
+				}),
+			);
+
+		const client = createDndApiSpellClient({ fetcher });
+
+		await expect(client.searchSpells({ slotLevel: 0, query: "l" })).resolves.toEqual([
+			{
+				index: "dancing-lights",
+				name: "Dancing Lights",
+				level: 0,
+				url: "/api/2024/spells/dancing-lights",
+				source: "spell",
+			},
+			{
+				index: "light",
+				name: "Light",
+				level: 0,
+				url: "/api/2024/spells/light",
+				source: "spell",
+			},
+			{
+				index: "lay-on-hands",
+				name: "Lay on Hands",
+				level: 1,
+				url: "/api/2014/features/lay-on-hands",
+				source: "feature",
+			},
+		]);
+		expect(fetcher).toHaveBeenNthCalledWith(
+			1,
+			"https://api.open5e.com/v2/spells/?name__icontains=l&document__key__in=srd-2024&level__lte=0&fields=key,name,level",
+		);
+		expect(fetcher).toHaveBeenNthCalledWith(2, "https://www.dnd5eapi.co/api/2014/features?name=l");
+		expect(fetcher).toHaveBeenNthCalledWith(
+			3,
+			"https://www.dnd5eapi.co/api/2014/features/lay-on-hands",
+		);
+	});
+
+	it("includes Paladin oath Channel Divinity features in non-slot search", async () => {
+		const fetcher = vi
+			.fn()
+			.mockResolvedValueOnce(jsonResponse({ results: [] }))
+			.mockResolvedValueOnce(
+				jsonResponse({
+					results: [
+						{
+							index: "channel-divinity-sacred-weapon",
+							name: "Channel Divinity: Sacred Weapon",
+						},
+					],
+				}),
+			)
+			.mockResolvedValueOnce(
+				jsonResponse({
+					index: "channel-divinity-sacred-weapon",
+					name: "Channel Divinity: Sacred Weapon",
+					level: 3,
+					url: "/api/2014/features/channel-divinity-sacred-weapon",
+					desc: [
+						"As an action, you can imbue one weapon that you are holding with positive energy.",
+					],
+					class: { name: "Paladin" },
+				}),
+			);
+
+		const client = createDndApiSpellClient({ fetcher });
+
+		await expect(client.searchSpells({ slotLevel: 0, query: "channel divinity" })).resolves.toEqual(
+			[
+				{
+					index: "channel-divinity-sacred-weapon",
+					name: "Channel Divinity: Sacred Weapon",
+					level: 3,
+					url: "/api/2014/features/channel-divinity-sacred-weapon",
+					source: "feature",
+				},
+			],
+		);
+	});
+
+	it("does not search class features in numbered slot mode", async () => {
+		const fetcher = vi.fn().mockResolvedValue(
+			jsonResponse({
+				results: [{ key: "srd-2024_divine-smite", name: "Divine Smite", level: 1 }],
+			}),
+		);
+
+		const client = createDndApiSpellClient({ fetcher });
+
+		await expect(client.searchSpells({ slotLevel: 1, query: "divinity" })).resolves.toEqual([]);
+		expect(fetcher).toHaveBeenCalledOnce();
+		expect(fetcher).toHaveBeenCalledWith(
+			"https://api.open5e.com/v2/spells/?name__icontains=divinity&document__key__in=srd-2024&level__lte=1&fields=key,name,level",
+		);
+	});
+});
+
+function jsonResponse(body: unknown) {
+	return {
+		ok: true,
+		json: async () => body,
+	} as Response;
+}

--- a/src/domains/characters/repo/dnd-api-spell-client.test.ts
+++ b/src/domains/characters/repo/dnd-api-spell-client.test.ts
@@ -2,49 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 import { createDndApiSpellClient } from "./dnd-api-spell-client.js";
 
 describe("createDndApiSpellClient", () => {
-	it("returns no search results without calling the API for an empty query", async () => {
-		const fetcher = vi.fn();
-		const client = createDndApiSpellClient({ fetcher });
-
-		await expect(client.searchSpells({ slotLevel: 3, query: " " })).resolves.toEqual([]);
-		expect(fetcher).not.toHaveBeenCalled();
-	});
-
-	it("searches SRD 2024 spells by name and includes spell levels up to the selected slot level", async () => {
-		const fetcher = vi.fn().mockResolvedValue(
-			jsonResponse({
-				results: [
-					{ key: "srd-2024_divine-smite", name: "Divine Smite", level: 1 },
-					{ key: "srd-2024_searing-smite", name: "Searing Smite", level: 1 },
-					{ key: "srd-2024_shining-smite", name: "Shining Smite", level: 2 },
-				],
-			}),
-		);
-
-		const client = createDndApiSpellClient({ fetcher });
-
-		await expect(client.searchSpells({ slotLevel: 1, query: "smite" })).resolves.toEqual([
-			{
-				index: "divine-smite",
-				name: "Divine Smite",
-				level: 1,
-				url: "/api/2024/spells/divine-smite",
-				source: "spell",
-			},
-			{
-				index: "searing-smite",
-				name: "Searing Smite",
-				level: 1,
-				url: "/api/2024/spells/searing-smite",
-				source: "spell",
-			},
-		]);
-		expect(fetcher).toHaveBeenCalledOnce();
-		expect(fetcher).toHaveBeenCalledWith(
-			"https://api.open5e.com/v2/spells/?name__icontains=smite&document__key__in=srd-2024&level__lte=1&fields=key,name,level",
-		);
-	});
-
 	it("loads a canonical SRD 2024 spell by index before saving", async () => {
 		const fetcher = vi.fn().mockResolvedValue(
 			jsonResponse({

--- a/src/domains/characters/repo/dnd-api-spell-client.ts
+++ b/src/domains/characters/repo/dnd-api-spell-client.ts
@@ -5,7 +5,7 @@ import {
 	DndSpellSearchResultSchema,
 	SpellIndexSchema,
 } from "../types/index.js";
-import { getLegacySpellDetails } from "./dnd-api-legacy-spell-client.js";
+import { getLegacySpellDetails, searchLegacyFeatures } from "./dnd-api-legacy-spell-client.js";
 
 const OPEN5E_API_BASE_URL = "https://api.open5e.com/v2";
 const DND_API_2014_REST_BASE_URL = "https://www.dnd5eapi.co";
@@ -81,9 +81,9 @@ export function createDndApiSpellClient(options: DndApiSpellClientOptions = {}):
 			try {
 				const query = input.query.trim().toLowerCase();
 				if (query.length === 0) return [];
-				return (await searchEntries(open5eBaseUrl, fetcher, input.slotLevel, query)).sort(
-					compareSearchResults,
-				);
+				return (
+					await searchEntries(open5eBaseUrl, legacyBaseUrl, fetcher, input.slotLevel, query)
+				).sort(compareSearchResults);
 			} catch (error) {
 				if (error instanceof DndApiSpellClientError) throw error;
 				throw new DndApiSpellClientError();
@@ -119,6 +119,20 @@ export function createDndApiSpellClient(options: DndApiSpellClientOptions = {}):
 
 async function searchEntries(
 	open5eBaseUrl: string,
+	legacyBaseUrl: string,
+	fetcher: typeof fetch,
+	slotLevel: number,
+	query: string,
+) {
+	const spells = await searchOpen5eSpells(open5eBaseUrl, fetcher, slotLevel, query);
+	if (slotLevel !== 0) return spells;
+
+	const features = await searchLegacyFeatures(legacyBaseUrl, fetcher, query);
+	return [...spells, ...features];
+}
+
+async function searchOpen5eSpells(
+	open5eBaseUrl: string,
 	fetcher: typeof fetch,
 	slotLevel: number,
 	query: string,
@@ -128,7 +142,7 @@ async function searchEntries(
 
 	const parsed = Open5eSearchResponseSchema.parse(await response.json());
 	return parsed.results
-		.filter((spell) => spell.level >= 1 && spell.level <= slotLevel)
+		.filter((spell) => isSpellInBucket(spell.level, slotLevel))
 		.filter((spell) => matchesName(spell.name, query))
 		.map(parseOpen5eSearchResult);
 }
@@ -142,6 +156,11 @@ function parseOpen5eSearchResult(entry: { key: string; level: number; name: stri
 		url: spellApiUrl(index, "spell", "2024"),
 		source: "spell",
 	});
+}
+
+function isSpellInBucket(spellLevel: number, slotLevel: number) {
+	if (slotLevel === 0) return spellLevel === 0;
+	return spellLevel >= 1 && spellLevel <= slotLevel;
 }
 
 function spellApiUrl(index: string, source: SpellEntrySource, version: "2014" | "2024") {

--- a/src/domains/characters/runtime/routes.spells.test.ts
+++ b/src/domains/characters/runtime/routes.spells.test.ts
@@ -51,6 +51,17 @@ describe("registerCharacterRoutes spell routes", () => {
 				},
 			],
 		};
+		const nonSlotSearch = {
+			spells: [
+				{
+					index: "light",
+					name: "Light",
+					level: 0,
+					url: "/api/2024/spells/light",
+					source: "spell",
+				},
+			],
+		};
 		const details = {
 			spell: {
 				id: "00000000-0000-4000-8000-000000000030",
@@ -67,7 +78,9 @@ describe("registerCharacterRoutes spell routes", () => {
 		};
 		services.characterSpellService.listCharacterSpells.mockResolvedValue(spells);
 		services.characterSpellService.getCharacterSpellDetails.mockResolvedValue(details);
-		services.characterSpellService.searchCharacterSpells.mockResolvedValue(search);
+		services.characterSpellService.searchCharacterSpells
+			.mockResolvedValueOnce(search)
+			.mockResolvedValueOnce(nonSlotSearch);
 		services.characterSpellService.saveCharacterSpell.mockResolvedValue(spells);
 		services.characterSpellService.removeCharacterSpell.mockResolvedValue({ spells: [] });
 		const app = await buildApp(services);
@@ -95,6 +108,16 @@ describe("registerCharacterRoutes spell routes", () => {
 				method: "DELETE",
 				url: `/api/characters/${character.id}/spells/00000000-0000-4000-8000-000000000030`,
 			});
+			const nonSlotSearchResponse = await app.inject({
+				method: "POST",
+				url: `/api/characters/${character.id}/spells/search`,
+				payload: { slotLevel: 0, query: "light" },
+			});
+			const nonSlotSaveResponse = await app.inject({
+				method: "POST",
+				url: `/api/characters/${character.id}/spells`,
+				payload: { slotLevel: 0, spellIndex: "light", source: "spell" },
+			});
 
 			expect(listResponse.json()).toEqual(spells);
 			expect(searchResponse.json()).toEqual(search);
@@ -102,6 +125,9 @@ describe("registerCharacterRoutes spell routes", () => {
 			expect(saveResponse.json()).toEqual(spells);
 			expect(removeResponse.statusCode).toBe(200);
 			expect(removeResponse.json()).toEqual({ spells: [] });
+			expect(nonSlotSearchResponse.statusCode).toBe(200);
+			expect(nonSlotSearchResponse.json()).toEqual(nonSlotSearch);
+			expect(nonSlotSaveResponse.statusCode).toBe(200);
 			expect(services.characterSpellService.getCharacterSpellDetails).toHaveBeenCalledWith(
 				userId,
 				character.id,
@@ -112,6 +138,11 @@ describe("registerCharacterRoutes spell routes", () => {
 				character.id,
 				{ slotLevel: 3, query: "miss" },
 			);
+			expect(services.characterSpellService.searchCharacterSpells).toHaveBeenCalledWith(
+				userId,
+				character.id,
+				{ slotLevel: 0, query: "light" },
+			);
 			expect(services.characterSpellService.saveCharacterSpell).toHaveBeenCalledWith(
 				userId,
 				character.id,
@@ -121,6 +152,11 @@ describe("registerCharacterRoutes spell routes", () => {
 				userId,
 				character.id,
 				"00000000-0000-4000-8000-000000000030",
+			);
+			expect(services.characterSpellService.saveCharacterSpell).toHaveBeenCalledWith(
+				userId,
+				character.id,
+				{ slotLevel: 0, spellIndex: "light", source: "spell" },
 			);
 		} finally {
 			await app.close();

--- a/src/domains/characters/service/character-spell-service-save.test.ts
+++ b/src/domains/characters/service/character-spell-service-save.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CharacterSpellRepository, DndApiSpellClient } from "../repo/index.js";
+import type { CharacterSpell } from "../types/index.js";
+import { SpellSlotUnavailableError } from "./character-errors.js";
+import { createCharacterSpellService } from "./character-spell-service.js";
+
+describe("createCharacterSpellService save behavior", () => {
+	it("saves a canonical D&D spell to the selected character slot level", async () => {
+		const repository = fakeRepository();
+		const spellsClient = fakeSpellsClient();
+		spellsClient.findSpell.mockResolvedValue(spellResult("magic-missile", 1));
+		repository.saveCharacterSpell.mockResolvedValue({
+			spells: [savedSpell({ slotLevel: 3, spellIndex: "magic-missile", level: 1 })],
+		});
+
+		const service = createCharacterSpellService(repository, spellsClient);
+
+		await expect(
+			service.saveCharacterSpell("user-1", "character-1", {
+				slotLevel: 3,
+				spellIndex: "magic-missile",
+				source: "spell",
+			}),
+		).resolves.toEqual({
+			spells: [savedSpell({ slotLevel: 3, spellIndex: "magic-missile", level: 1 })],
+		});
+		expect(repository.saveCharacterSpell).toHaveBeenCalledWith("user-1", "character-1", {
+			slotLevel: 3,
+			spellIndex: "magic-missile",
+			name: "Magic Missile",
+			level: 1,
+			url: "/api/2024/spells/magic-missile",
+			source: "spell",
+		});
+	});
+
+	it("saves a canonical D&D feature to the non-slot bucket", async () => {
+		const repository = fakeRepository();
+		const spellsClient = fakeSpellsClient();
+		spellsClient.findSpell.mockResolvedValue(featureResult("divine-smite", 2));
+		repository.saveCharacterSpell.mockResolvedValue({
+			spells: [
+				savedSpell({
+					slotLevel: 0,
+					spellIndex: "divine-smite",
+					level: 2,
+					source: "feature",
+				}),
+			],
+		});
+
+		const service = createCharacterSpellService(repository, spellsClient);
+
+		await expect(
+			service.saveCharacterSpell("user-1", "character-1", {
+				slotLevel: 0,
+				spellIndex: "divine-smite",
+				source: "feature",
+			}),
+		).resolves.toEqual({
+			spells: [
+				savedSpell({
+					slotLevel: 0,
+					spellIndex: "divine-smite",
+					level: 2,
+					source: "feature",
+				}),
+			],
+		});
+		expect(spellsClient.findSpell).toHaveBeenCalledWith("divine-smite", "feature");
+		expect(repository.saveCharacterSpell).toHaveBeenCalledWith("user-1", "character-1", {
+			slotLevel: 0,
+			spellIndex: "divine-smite",
+			name: "Divine Smite",
+			level: 2,
+			url: "/api/2014/features/divine-smite",
+			source: "feature",
+		});
+	});
+
+	it("saves a canonical cantrip to the non-slot bucket", async () => {
+		const repository = fakeRepository();
+		const spellsClient = fakeSpellsClient();
+		spellsClient.findSpell.mockResolvedValue(spellResult("light", 0));
+		repository.saveCharacterSpell.mockResolvedValue({
+			spells: [savedSpell({ slotLevel: 0, spellIndex: "light", level: 0 })],
+		});
+
+		const service = createCharacterSpellService(repository, spellsClient);
+
+		await expect(
+			service.saveCharacterSpell("user-1", "character-1", {
+				slotLevel: 0,
+				spellIndex: "light",
+				source: "spell",
+			}),
+		).resolves.toEqual({
+			spells: [savedSpell({ slotLevel: 0, spellIndex: "light", level: 0 })],
+		});
+		expect(repository.saveCharacterSpell).toHaveBeenCalledWith("user-1", "character-1", {
+			slotLevel: 0,
+			spellIndex: "light",
+			name: "Light",
+			level: 0,
+			url: "/api/2024/spells/light",
+			source: "spell",
+		});
+	});
+
+	it("rejects saving a spell above the selected slot level", async () => {
+		const repository = fakeRepository();
+		const spellsClient = fakeSpellsClient();
+		spellsClient.findSpell.mockResolvedValue(spellResult("fireball", 3));
+
+		const service = createCharacterSpellService(repository, spellsClient);
+
+		await expect(
+			service.saveCharacterSpell("user-1", "character-1", {
+				slotLevel: 2,
+				spellIndex: "fireball",
+				source: "spell",
+			}),
+		).rejects.toThrow(SpellSlotUnavailableError);
+		expect(repository.saveCharacterSpell).not.toHaveBeenCalled();
+	});
+
+	it("rejects saving cantrips to numbered slots and leveled spells to the non-slot bucket", async () => {
+		const repository = fakeRepository();
+		const spellsClient = fakeSpellsClient();
+		const service = createCharacterSpellService(repository, spellsClient);
+
+		spellsClient.findSpell.mockResolvedValueOnce(spellResult("light", 0));
+		await expect(
+			service.saveCharacterSpell("user-1", "character-1", {
+				slotLevel: 1,
+				spellIndex: "light",
+				source: "spell",
+			}),
+		).rejects.toThrow(SpellSlotUnavailableError);
+
+		spellsClient.findSpell.mockResolvedValueOnce(spellResult("magic-missile", 1));
+		await expect(
+			service.saveCharacterSpell("user-1", "character-1", {
+				slotLevel: 0,
+				spellIndex: "magic-missile",
+				source: "spell",
+			}),
+		).rejects.toThrow(SpellSlotUnavailableError);
+
+		expect(repository.saveCharacterSpell).not.toHaveBeenCalled();
+	});
+
+	it("rejects saving features to numbered spell slots", async () => {
+		const repository = fakeRepository();
+		const spellsClient = fakeSpellsClient();
+		spellsClient.findSpell.mockResolvedValue(featureResult("lay-on-hands", 1));
+
+		const service = createCharacterSpellService(repository, spellsClient);
+
+		await expect(
+			service.saveCharacterSpell("user-1", "character-1", {
+				slotLevel: 1,
+				spellIndex: "lay-on-hands",
+				source: "feature",
+			}),
+		).rejects.toThrow(SpellSlotUnavailableError);
+		expect(repository.saveCharacterSpell).not.toHaveBeenCalled();
+	});
+});
+
+function fakeRepository() {
+	return {
+		characterExists: vi.fn().mockResolvedValue(true),
+		getCharacterSpell: vi.fn(),
+		listCharacterSpells: vi.fn().mockResolvedValue([]),
+		removeCharacterSpell: vi.fn(),
+		saveCharacterSpell: vi.fn(),
+	} satisfies {
+		[K in keyof CharacterSpellRepository]: CharacterSpellRepository[K] extends (
+			...args: infer A
+		) => infer R
+			? ReturnType<typeof vi.fn<(...args: A) => R>>
+			: never;
+	};
+}
+
+function fakeSpellsClient() {
+	return {
+		searchSpells: vi.fn(),
+		findSpell: vi.fn(),
+		getSpellDetails: vi.fn(),
+	} satisfies {
+		[K in keyof DndApiSpellClient]: DndApiSpellClient[K] extends (...args: infer A) => infer R
+			? ReturnType<typeof vi.fn<(...args: A) => R>>
+			: never;
+	};
+}
+
+function spellResult(spellIndex: string, level: number) {
+	return {
+		index: spellIndex,
+		name: spellName(spellIndex),
+		level,
+		url: `/api/2024/spells/${spellIndex}`,
+		source: "spell" as const,
+	};
+}
+
+function featureResult(spellIndex: string, level: number) {
+	return {
+		index: spellIndex,
+		name: spellName(spellIndex),
+		level,
+		url: `/api/2014/features/${spellIndex}`,
+		source: "feature" as const,
+	};
+}
+
+function savedSpell({
+	level,
+	slotLevel,
+	spellIndex,
+	source = "spell",
+}: {
+	level: number;
+	slotLevel: number;
+	spellIndex: string;
+	source?: "feature" | "spell";
+}): CharacterSpell {
+	return {
+		id: "00000000-0000-4000-8000-000000000030",
+		slotLevel,
+		spellIndex,
+		name: spellName(spellIndex),
+		level,
+		url:
+			source === "feature" ? `/api/2014/features/${spellIndex}` : `/api/2024/spells/${spellIndex}`,
+		source,
+	};
+}
+
+function spellName(spellIndex: string) {
+	const names: Record<string, string> = {
+		"divine-smite": "Divine Smite",
+		fireball: "Fireball",
+		"lay-on-hands": "Lay on Hands",
+		light: "Light",
+		"magic-missile": "Magic Missile",
+	};
+	return names[spellIndex] ?? "Magic Missile";
+}

--- a/src/domains/characters/service/character-spell-service.test.ts
+++ b/src/domains/characters/service/character-spell-service.test.ts
@@ -39,91 +39,6 @@ describe("createCharacterSpellService", () => {
 		expect(spellsClient.searchSpells).toHaveBeenCalledWith({ slotLevel: 3, query: "miss" });
 	});
 
-	it("saves a canonical D&D spell to the selected character slot level", async () => {
-		const repository = fakeRepository();
-		const spellsClient = fakeSpellsClient();
-		spellsClient.findSpell.mockResolvedValue({
-			index: "magic-missile",
-			name: "Magic Missile",
-			level: 1,
-			url: "/api/2014/spells/magic-missile",
-			source: "spell",
-		});
-		repository.saveCharacterSpell.mockResolvedValue({
-			spells: [savedSpell({ slotLevel: 3, spellIndex: "magic-missile", level: 1 })],
-		});
-
-		const service = createCharacterSpellService(repository, spellsClient);
-
-		await expect(
-			service.saveCharacterSpell("user-1", "character-1", {
-				slotLevel: 3,
-				spellIndex: "magic-missile",
-				source: "spell",
-			}),
-		).resolves.toEqual({
-			spells: [savedSpell({ slotLevel: 3, spellIndex: "magic-missile", level: 1 })],
-		});
-		expect(repository.saveCharacterSpell).toHaveBeenCalledWith("user-1", "character-1", {
-			slotLevel: 3,
-			spellIndex: "magic-missile",
-			name: "Magic Missile",
-			level: 1,
-			url: "/api/2014/spells/magic-missile",
-			source: "spell",
-		});
-	});
-
-	it("saves a canonical D&D feature to the selected character slot level", async () => {
-		const repository = fakeRepository();
-		const spellsClient = fakeSpellsClient();
-		spellsClient.findSpell.mockResolvedValue({
-			index: "divine-smite",
-			name: "Divine Smite",
-			level: 2,
-			url: "/api/2014/features/divine-smite",
-			source: "feature",
-		});
-		repository.saveCharacterSpell.mockResolvedValue({
-			spells: [
-				savedSpell({
-					slotLevel: 1,
-					spellIndex: "divine-smite",
-					level: 2,
-					source: "feature",
-				}),
-			],
-		});
-
-		const service = createCharacterSpellService(repository, spellsClient);
-
-		await expect(
-			service.saveCharacterSpell("user-1", "character-1", {
-				slotLevel: 1,
-				spellIndex: "divine-smite",
-				source: "feature",
-			}),
-		).resolves.toEqual({
-			spells: [
-				savedSpell({
-					slotLevel: 1,
-					spellIndex: "divine-smite",
-					level: 2,
-					source: "feature",
-				}),
-			],
-		});
-		expect(spellsClient.findSpell).toHaveBeenCalledWith("divine-smite", "feature");
-		expect(repository.saveCharacterSpell).toHaveBeenCalledWith("user-1", "character-1", {
-			slotLevel: 1,
-			spellIndex: "divine-smite",
-			name: "Divine Smite",
-			level: 2,
-			url: "/api/2014/features/divine-smite",
-			source: "feature",
-		});
-	});
-
 	it("loads details for a saved character spell", async () => {
 		const repository = fakeRepository();
 		const spellsClient = fakeSpellsClient();
@@ -275,7 +190,11 @@ function savedSpell({
 				? "Fireball"
 				: spellIndex === "divine-smite"
 					? "Divine Smite"
-					: "Magic Missile",
+					: spellIndex === "light"
+						? "Light"
+						: spellIndex === "lay-on-hands"
+							? "Lay on Hands"
+							: "Magic Missile",
 		level,
 		url: `/api/2014/${source === "feature" ? "features" : "spells"}/${spellIndex}`,
 		source,

--- a/src/domains/characters/service/character-spell-service.ts
+++ b/src/domains/characters/service/character-spell-service.ts
@@ -110,9 +110,7 @@ export function createCharacterSpellService(
 			try {
 				const source = input.source ?? "spell";
 				const spell = await spellsClient.findSpell(input.spellIndex, source);
-				if (spell.source === "spell" && spell.level > input.slotLevel) {
-					throw new SpellSlotUnavailableError("Spell level is too high for this slot.");
-				}
+				assertSpellCanSaveToBucket(spell, input.slotLevel);
 
 				const response = await repository.saveCharacterSpell(userId, characterId, {
 					slotLevel: input.slotLevel,
@@ -138,4 +136,31 @@ export function createCharacterSpellService(
 			return response;
 		},
 	};
+}
+
+function assertSpellCanSaveToBucket(
+	spell: { level: number; source: "feature" | "spell" },
+	slotLevel: number,
+) {
+	if (spell.source === "feature") {
+		if (slotLevel !== 0) {
+			throw new SpellSlotUnavailableError("Features must be saved outside spell slots.");
+		}
+		return;
+	}
+
+	if (slotLevel === 0) {
+		if (spell.level !== 0) {
+			throw new SpellSlotUnavailableError("Leveled spells require a spell slot.");
+		}
+		return;
+	}
+
+	if (spell.level === 0) {
+		throw new SpellSlotUnavailableError("Cantrips must be saved outside spell slots.");
+	}
+
+	if (spell.level > slotLevel) {
+		throw new SpellSlotUnavailableError("Spell level is too high for this slot.");
+	}
 }

--- a/src/domains/characters/types/character-spell.test.ts
+++ b/src/domains/characters/types/character-spell.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+	CharacterSpellDetailsResponseSchema,
+	CharacterSpellsResponseSchema,
+	SaveCharacterSpellRequestSchema,
+	SearchCharacterSpellsRequestSchema,
+	SearchCharacterSpellsResponseSchema,
+	UseCharacterSpellSlotRequestSchema,
+} from "./character.js";
+
+describe("Character spell schemas", () => {
+	it("accepts a saved character spell under a slot level", () => {
+		const response = {
+			spells: [
+				{
+					id: "00000000-0000-4000-8000-000000000030",
+					slotLevel: 3,
+					spellIndex: "magic-missile",
+					name: "Magic Missile",
+					level: 1,
+					url: "/api/2014/spells/magic-missile",
+					source: "spell",
+				},
+			],
+		};
+
+		expect(CharacterSpellsResponseSchema.parse(response)).toEqual(response);
+	});
+
+	it("accepts a saved class feature in the non-slot bucket", () => {
+		const response = {
+			spells: [
+				{
+					id: "00000000-0000-4000-8000-000000000031",
+					slotLevel: 0,
+					spellIndex: "lay-on-hands",
+					name: "Lay on Hands",
+					level: 1,
+					url: "/api/2014/features/lay-on-hands",
+					source: "feature",
+				},
+			],
+		};
+
+		expect(CharacterSpellsResponseSchema.parse(response)).toEqual(response);
+	});
+
+	it("accepts class features above 9th level", () => {
+		const response = {
+			spells: [
+				{
+					id: "00000000-0000-4000-8000-000000000032",
+					slotLevel: 0,
+					spellIndex: "improved-divine-smite",
+					name: "Improved Divine Smite",
+					level: 11,
+					url: "/api/2014/features/improved-divine-smite",
+					source: "feature",
+				},
+			],
+		};
+
+		expect(CharacterSpellsResponseSchema.parse(response)).toEqual(response);
+	});
+
+	it("accepts a spell search request and response", () => {
+		expect(SearchCharacterSpellsRequestSchema.parse({ slotLevel: 3, query: "miss" })).toEqual({
+			slotLevel: 3,
+			query: "miss",
+		});
+
+		const response = {
+			spells: [
+				{
+					index: "magic-missile",
+					name: "Magic Missile",
+					level: 1,
+					url: "/api/2024/spells/magic-missile",
+					source: "spell",
+				},
+				{
+					index: "divine-smite",
+					name: "Divine Smite",
+					level: 2,
+					url: "/api/2014/features/divine-smite",
+					source: "feature",
+				},
+			],
+		};
+
+		expect(SearchCharacterSpellsResponseSchema.parse(response)).toEqual(response);
+	});
+
+	it("accepts saving a spell by D&D API index and slot level", () => {
+		expect(
+			SaveCharacterSpellRequestSchema.parse({
+				slotLevel: 3,
+				spellIndex: "magic-missile",
+				source: "spell",
+			}),
+		).toEqual({
+			slotLevel: 3,
+			spellIndex: "magic-missile",
+			source: "spell",
+		});
+	});
+
+	it("accepts saved spell details with description and display metadata", () => {
+		const response = {
+			spell: {
+				id: "00000000-0000-4000-8000-000000000030",
+				slotLevel: 3,
+				spellIndex: "magic-missile",
+				name: "Magic Missile",
+				level: 1,
+				url: "/api/2014/spells/magic-missile",
+				source: "spell",
+				desc: ["You create three glowing darts of magical force."],
+				higherLevel: ["One more dart is created for each slot level above 1st."],
+				metadata: [
+					{ label: "Casting Time", value: "1 action" },
+					{ label: "Range", value: "120 feet" },
+				],
+			},
+		};
+
+		expect(CharacterSpellDetailsResponseSchema.parse(response)).toEqual(response);
+	});
+
+	it("accepts cantrips in the non-slot spell bucket", () => {
+		const response = {
+			spells: [
+				{
+					id: "00000000-0000-4000-8000-000000000031",
+					slotLevel: 0,
+					spellIndex: "light",
+					name: "Light",
+					level: 0,
+					url: "/api/2014/spells/light",
+					source: "spell",
+				},
+			],
+		};
+
+		expect(CharacterSpellsResponseSchema.parse(response)).toEqual(response);
+		expect(
+			SaveCharacterSpellRequestSchema.parse({
+				slotLevel: 0,
+				spellIndex: "light",
+				source: "spell",
+			}),
+		).toEqual({
+			slotLevel: 0,
+			spellIndex: "light",
+			source: "spell",
+		});
+	});
+
+	it("keeps spell slot usage requests constrained to numbered slots", () => {
+		expect(() => UseCharacterSpellSlotRequestSchema.parse({ level: 0 })).toThrow();
+		expect(() => UseCharacterSpellSlotRequestSchema.parse({ level: 10 })).toThrow();
+	});
+});

--- a/src/domains/characters/types/character.test.ts
+++ b/src/domains/characters/types/character.test.ts
@@ -1,13 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
 	CharacterDetailResponseSchema,
-	CharacterSpellDetailsResponseSchema,
 	CharacterSpellSlotsResponseSchema,
-	CharacterSpellsResponseSchema,
 	CreateCharacterRequestSchema,
-	SaveCharacterSpellRequestSchema,
-	SearchCharacterSpellsRequestSchema,
-	SearchCharacterSpellsResponseSchema,
 	UpdateCharacterHealthRequestSchema,
 	UpdateCharacterLevelRequestSchema,
 	UpdateCharacterSpellSlotsRequestSchema,
@@ -38,143 +33,6 @@ describe("CreateCharacterRequestSchema", () => {
 				className: "Wizard",
 				level: 21,
 				maxHp: 12,
-			}),
-		).toThrow();
-	});
-});
-
-describe("Character spell schemas", () => {
-	it("accepts a saved character spell under a slot level", () => {
-		const response = {
-			spells: [
-				{
-					id: "00000000-0000-4000-8000-000000000030",
-					slotLevel: 3,
-					spellIndex: "magic-missile",
-					name: "Magic Missile",
-					level: 1,
-					url: "/api/2014/spells/magic-missile",
-					source: "spell",
-				},
-			],
-		};
-
-		expect(CharacterSpellsResponseSchema.parse(response)).toEqual(response);
-	});
-
-	it("accepts a saved class feature under a slot level", () => {
-		const response = {
-			spells: [
-				{
-					id: "00000000-0000-4000-8000-000000000031",
-					slotLevel: 1,
-					spellIndex: "lay-on-hands",
-					name: "Lay on Hands",
-					level: 1,
-					url: "/api/2014/features/lay-on-hands",
-					source: "feature",
-				},
-			],
-		};
-
-		expect(CharacterSpellsResponseSchema.parse(response)).toEqual(response);
-	});
-
-	it("accepts class features above 9th level", () => {
-		const response = {
-			spells: [
-				{
-					id: "00000000-0000-4000-8000-000000000032",
-					slotLevel: 1,
-					spellIndex: "improved-divine-smite",
-					name: "Improved Divine Smite",
-					level: 11,
-					url: "/api/2014/features/improved-divine-smite",
-					source: "feature",
-				},
-			],
-		};
-
-		expect(CharacterSpellsResponseSchema.parse(response)).toEqual(response);
-	});
-
-	it("accepts a spell search request and response", () => {
-		expect(SearchCharacterSpellsRequestSchema.parse({ slotLevel: 3, query: "miss" })).toEqual({
-			slotLevel: 3,
-			query: "miss",
-		});
-
-		const response = {
-			spells: [
-				{
-					index: "magic-missile",
-					name: "Magic Missile",
-					level: 1,
-					url: "/api/2024/spells/magic-missile",
-					source: "spell",
-				},
-				{
-					index: "divine-smite",
-					name: "Divine Smite",
-					level: 2,
-					url: "/api/2014/features/divine-smite",
-					source: "feature",
-				},
-			],
-		};
-
-		expect(SearchCharacterSpellsResponseSchema.parse(response)).toEqual(response);
-	});
-
-	it("accepts saving a spell by D&D API index and slot level", () => {
-		expect(
-			SaveCharacterSpellRequestSchema.parse({
-				slotLevel: 3,
-				spellIndex: "magic-missile",
-				source: "spell",
-			}),
-		).toEqual({
-			slotLevel: 3,
-			spellIndex: "magic-missile",
-			source: "spell",
-		});
-	});
-
-	it("accepts saved spell details with description and display metadata", () => {
-		const response = {
-			spell: {
-				id: "00000000-0000-4000-8000-000000000030",
-				slotLevel: 3,
-				spellIndex: "magic-missile",
-				name: "Magic Missile",
-				level: 1,
-				url: "/api/2014/spells/magic-missile",
-				source: "spell",
-				desc: ["You create three glowing darts of magical force."],
-				higherLevel: ["One more dart is created for each slot level above 1st."],
-				metadata: [
-					{ label: "Casting Time", value: "1 action" },
-					{ label: "Range", value: "120 feet" },
-				],
-			},
-		};
-
-		expect(CharacterSpellDetailsResponseSchema.parse(response)).toEqual(response);
-	});
-
-	it("rejects cantrips and spells above the slot range for saved spell payloads", () => {
-		expect(() =>
-			CharacterSpellsResponseSchema.parse({
-				spells: [
-					{
-						id: "00000000-0000-4000-8000-000000000031",
-						slotLevel: 1,
-						spellIndex: "light",
-						name: "Light",
-						level: 0,
-						url: "/api/2014/spells/light",
-					},
-				],
 			}),
 		).toThrow();
 	});

--- a/src/domains/characters/types/character.ts
+++ b/src/domains/characters/types/character.ts
@@ -28,6 +28,7 @@ export const CharacterLevelSchema = z.number().int().min(1).max(20);
 export const HitPointsSchema = z.number().int().min(0).max(9999);
 export const MaxHitPointsSchema = z.number().int().min(1).max(9999);
 export const SpellSlotLevelSchema = z.number().int().min(1).max(9);
+export const SpellListBucketLevelSchema = z.number().int().min(0).max(9);
 export const SpellSlotCountSchema = z.number().int().min(0).max(99);
 export const SpellSlotActionSchema = z.enum(["configured", "used", "restored", "defaults-applied"]);
 export type SpellSlotAction = z.infer<typeof SpellSlotActionSchema>;
@@ -38,7 +39,7 @@ export const SpellIndexSchema = z
 	.regex(/^[a-z0-9-]+$/);
 export type SpellIndex = z.infer<typeof SpellIndexSchema>;
 export const SpellNameSchema = z.string().min(1).max(120).regex(/\S/);
-export const SpellLevelSchema = z.number().int().min(1).max(20);
+export const SpellLevelSchema = z.number().int().min(0).max(20);
 export type SpellLevel = z.infer<typeof SpellLevelSchema>;
 export const SpellEntrySourceSchema = z.enum(["spell", "feature"]);
 export type SpellEntrySource = z.infer<typeof SpellEntrySourceSchema>;
@@ -215,7 +216,7 @@ export type CharacterSpellSlotsResponse = z.infer<typeof CharacterSpellSlotsResp
 
 export const CharacterSpellSchema = z.object({
 	id: CharacterSpellIdSchema,
-	slotLevel: SpellSlotLevelSchema,
+	slotLevel: SpellListBucketLevelSchema,
 	spellIndex: SpellIndexSchema,
 	name: SpellNameSchema,
 	level: SpellLevelSchema,
@@ -263,7 +264,7 @@ export const CharacterSpellDetailsResponseSchema = z.object({
 export type CharacterSpellDetailsResponse = z.infer<typeof CharacterSpellDetailsResponseSchema>;
 
 export const SearchCharacterSpellsRequestSchema = z.object({
-	slotLevel: SpellSlotLevelSchema,
+	slotLevel: SpellListBucketLevelSchema,
 	query: z.string().max(120),
 });
 export type SearchCharacterSpellsRequest = z.infer<typeof SearchCharacterSpellsRequestSchema>;
@@ -274,7 +275,7 @@ export const SearchCharacterSpellsResponseSchema = z.object({
 export type SearchCharacterSpellsResponse = z.infer<typeof SearchCharacterSpellsResponseSchema>;
 
 export const SaveCharacterSpellRequestSchema = z.object({
-	slotLevel: SpellSlotLevelSchema,
+	slotLevel: SpellListBucketLevelSchema,
 	spellIndex: SpellIndexSchema,
 	source: SpellEntrySourceSchema.default("spell"),
 });

--- a/src/domains/characters/types/index.ts
+++ b/src/domains/characters/types/index.ts
@@ -79,6 +79,7 @@ export {
 	SpellEntrySourceSchema,
 	SpellIndexSchema,
 	SpellLevelSchema,
+	SpellListBucketLevelSchema,
 	SpellNameSchema,
 	SpellSlotActionSchema,
 	SpellSlotChangeResponseSchema,

--- a/src/domains/characters/ui/non-slot-spell-list.test.tsx
+++ b/src/domains/characters/ui/non-slot-spell-list.test.tsx
@@ -1,0 +1,88 @@
+import { MantineProvider } from "@mantine/core";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { NonSlotSpellList } from "./non-slot-spell-list.js";
+
+describe("NonSlotSpellList", () => {
+	it("renders cantrips and features without spell slot controls", () => {
+		const html = renderToString(
+			<MantineProvider>
+				<NonSlotSpellList
+					characterSpells={[
+						{
+							id: "00000000-0000-4000-8000-000000000031",
+							slotLevel: 0,
+							spellIndex: "light",
+							name: "Light",
+							level: 0,
+							url: "/api/2014/spells/light",
+							source: "spell",
+						},
+						{
+							id: "00000000-0000-4000-8000-000000000032",
+							slotLevel: 0,
+							spellIndex: "lay-on-hands",
+							name: "Lay on Hands",
+							level: 1,
+							url: "/api/2014/features/lay-on-hands",
+							source: "feature",
+						},
+					]}
+					isEditing={false}
+					onOpenSpellDetails={vi.fn()}
+					onOpenSpellSearch={vi.fn()}
+					onRemoveSpell={vi.fn()}
+				/>
+			</MantineProvider>,
+		);
+
+		const readableHtml = html.replaceAll("<!-- -->", "");
+		expect(readableHtml).toContain("Cantrips &amp; features");
+		expect(html).toContain('aria-label="Add cantrip or feature"');
+		expect(html).toContain('aria-label="View Light details"');
+		expect(html).toContain('aria-label="View Lay on Hands details"');
+		expect(readableHtml).toContain("Light");
+		expect(readableHtml).toContain("Cantrip");
+		expect(readableHtml).toContain("Lay on Hands");
+		expect(readableHtml).toContain("1st-level feature");
+		expect(readableHtml).not.toContain("Use");
+		expect(readableHtml).not.toContain("Restore");
+		expect(html).not.toContain('aria-label="Remove Light"');
+	});
+
+	it("shows saved cantrip and feature remove controls while editing", () => {
+		const html = renderToString(
+			<MantineProvider>
+				<NonSlotSpellList
+					characterSpells={[
+						{
+							id: "00000000-0000-4000-8000-000000000031",
+							slotLevel: 0,
+							spellIndex: "light",
+							name: "Light",
+							level: 0,
+							url: "/api/2024/spells/light",
+							source: "spell",
+						},
+						{
+							id: "00000000-0000-4000-8000-000000000032",
+							slotLevel: 0,
+							spellIndex: "lay-on-hands",
+							name: "Lay on Hands",
+							level: 1,
+							url: "/api/2014/features/lay-on-hands",
+							source: "feature",
+						},
+					]}
+					isEditing={true}
+					onOpenSpellDetails={vi.fn()}
+					onOpenSpellSearch={vi.fn()}
+					onRemoveSpell={vi.fn()}
+				/>
+			</MantineProvider>,
+		);
+
+		expect(html).toContain('aria-label="Remove Light"');
+		expect(html).toContain('aria-label="Remove Lay on Hands"');
+	});
+});

--- a/src/domains/characters/ui/non-slot-spell-list.tsx
+++ b/src/domains/characters/ui/non-slot-spell-list.tsx
@@ -1,0 +1,76 @@
+import { Anchor, Button, Group, Stack, Text } from "@mantine/core";
+import type { CharacterSpellsResponse } from "../../../generated/api-client.generated.js";
+import { formatSpellEntryDetail } from "./spell-slot-format.js";
+
+interface NonSlotSpellListProps {
+	characterSpells: CharacterSpellsResponse["spells"];
+	isEditing: boolean;
+	onOpenSpellDetails: (spell: CharacterSpellsResponse["spells"][number]) => void;
+	onOpenSpellSearch: () => void;
+	onRemoveSpell: (spell: CharacterSpellsResponse["spells"][number]) => void;
+}
+
+export function NonSlotSpellList({
+	characterSpells,
+	isEditing,
+	onOpenSpellDetails,
+	onOpenSpellSearch,
+	onRemoveSpell,
+}: NonSlotSpellListProps) {
+	return (
+		<Stack gap="xs">
+			<Group align="center" justify="space-between" wrap="wrap">
+				<Text fw={600} size="sm">
+					Cantrips & features
+				</Text>
+				<Button
+					aria-label="Add cantrip or feature"
+					color="gray"
+					onClick={onOpenSpellSearch}
+					size="compact-xs"
+					variant="subtle"
+				>
+					+
+				</Button>
+			</Group>
+			{characterSpells.length > 0 ? (
+				<Stack gap={2}>
+					{characterSpells.map((spell) => (
+						<Group key={spell.id} justify="space-between" gap="xs" wrap="nowrap">
+							<Stack gap={0} style={{ flex: "1 1 auto", minWidth: 0 }}>
+								<Anchor
+									aria-label={`View ${spell.name} details`}
+									component="button"
+									onClick={() => onOpenSpellDetails(spell)}
+									size="sm"
+									ta="left"
+									type="button"
+								>
+									{spell.name}
+								</Anchor>
+								<Text c="dimmed" size="xs">
+									{formatSpellEntryDetail(spell)}
+								</Text>
+							</Stack>
+							{isEditing && (
+								<Button
+									aria-label={`Remove ${spell.name}`}
+									color="red"
+									onClick={() => onRemoveSpell(spell)}
+									size="compact-xs"
+									variant="subtle"
+								>
+									Remove
+								</Button>
+							)}
+						</Group>
+					))}
+				</Stack>
+			) : (
+				<Text c="dimmed" size="sm">
+					No cantrips or features saved.
+				</Text>
+			)}
+		</Stack>
+	);
+}

--- a/src/domains/characters/ui/spell-search-modal.test.tsx
+++ b/src/domains/characters/ui/spell-search-modal.test.tsx
@@ -41,8 +41,41 @@ describe("SpellSearchModal", () => {
 		expect(readableHtml).toContain("Add spell to 3rd-level");
 		expect(readableHtml).toContain("Search spells");
 		expect(readableHtml).toContain("Magic Missile");
-		expect(readableHtml).toContain("Spell 1st-level");
+		expect(readableHtml).toContain("1st-level spell");
 		expect(readableHtml).toContain("Divine Smite");
-		expect(readableHtml).toContain("Feature 2nd-level");
+		expect(readableHtml).toContain("2nd-level feature");
+	});
+
+	it("renders non-slot search copy for cantrips and features", () => {
+		const html = renderToString(
+			<MantineProvider>
+				<SpellSearchModal
+					onChangeQuery={vi.fn()}
+					onClose={vi.fn()}
+					onSaveSpell={vi.fn()}
+					opened
+					pending={false}
+					query="light"
+					results={[
+						{
+							index: "light",
+							name: "Light",
+							level: 0,
+							url: "/api/2014/spells/light",
+							source: "spell",
+						},
+					]}
+					searched
+					slotLevel={0}
+					withinPortal={false}
+				/>
+			</MantineProvider>,
+		);
+
+		const readableHtml = html.replaceAll("<!-- -->", "");
+		expect(readableHtml).toContain("Add cantrip or feature");
+		expect(readableHtml).toContain("Search cantrips and features");
+		expect(readableHtml).toContain("Light");
+		expect(readableHtml).toContain("Cantrip");
 	});
 });

--- a/src/domains/characters/ui/spell-search-modal.tsx
+++ b/src/domains/characters/ui/spell-search-modal.tsx
@@ -1,6 +1,6 @@
 import { Button, Group, Modal, Stack, Text, TextInput } from "@mantine/core";
 import type { SearchCharacterSpellsResponse } from "../../../generated/api-client.generated.js";
-import { formatSpellLevel } from "./spell-slot-format.js";
+import { formatSpellEntryDetail, formatSpellLevel } from "./spell-slot-format.js";
 
 export type SpellSearchResult = SearchCharacterSpellsResponse["spells"][number];
 
@@ -33,16 +33,18 @@ export function SpellSearchModal({
 			fullScreen
 			onClose={onClose}
 			opened={opened}
-			title={`Add spell to ${formatSpellLevel(slotLevel)}`}
+			title={
+				slotLevel === 0 ? "Add cantrip or feature" : `Add spell to ${formatSpellLevel(slotLevel)}`
+			}
 			transitionProps={{ duration: 0 }}
 			withinPortal={withinPortal}
 		>
 			<Stack gap="md">
 				<TextInput
 					data-autofocus
-					label="Search spells"
+					label={slotLevel === 0 ? "Search cantrips and features" : "Search spells"}
 					onChange={(event) => onChangeQuery(event.currentTarget.value)}
-					placeholder="Spell name"
+					placeholder={slotLevel === 0 ? "Name" : "Spell name"}
 					size="md"
 					value={query}
 				/>
@@ -79,6 +81,5 @@ export function SpellSearchModal({
 }
 
 function formatSearchResultDetail(spell: SpellSearchResult) {
-	const entryType = spell.source === "feature" ? "Feature" : "Spell";
-	return `${entryType} ${formatSpellLevel(spell.level)}`;
+	return formatSpellEntryDetail(spell);
 }

--- a/src/domains/characters/ui/spell-slot-edit-actions.test.tsx
+++ b/src/domains/characters/ui/spell-slot-edit-actions.test.tsx
@@ -1,0 +1,38 @@
+import { MantineProvider } from "@mantine/core";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { SpellSlotEditActions } from "./spell-slot-edit-actions.js";
+
+describe("SpellSlotEditActions", () => {
+	it("renders spell edit actions only while editing", () => {
+		const hiddenHtml = renderToString(
+			<MantineProvider>
+				<SpellSlotEditActions
+					defaultsPending={false}
+					disabled={false}
+					isEditing={false}
+					onApplyDefaults={vi.fn()}
+					onSaveConfiguration={vi.fn()}
+					updatePending={false}
+				/>
+			</MantineProvider>,
+		);
+		const visibleHtml = renderToString(
+			<MantineProvider>
+				<SpellSlotEditActions
+					defaultsPending={false}
+					disabled={true}
+					isEditing={true}
+					onApplyDefaults={vi.fn()}
+					onSaveConfiguration={vi.fn()}
+					updatePending={false}
+				/>
+			</MantineProvider>,
+		);
+
+		expect(hiddenHtml).not.toContain("Apply class defaults");
+		expect(visibleHtml).toContain("Apply class defaults");
+		expect(visibleHtml).toContain("Apply changes");
+		expect(visibleHtml).toContain("disabled");
+	});
+});

--- a/src/domains/characters/ui/spell-slot-edit-actions.tsx
+++ b/src/domains/characters/ui/spell-slot-edit-actions.tsx
@@ -1,0 +1,44 @@
+import { Button, Group } from "@mantine/core";
+
+export function SpellSlotEditActions({
+	disabled,
+	defaultsPending,
+	isEditing,
+	onApplyDefaults,
+	onSaveConfiguration,
+	updatePending,
+}: {
+	disabled: boolean;
+	defaultsPending: boolean;
+	isEditing: boolean;
+	onApplyDefaults: () => void;
+	onSaveConfiguration: () => void;
+	updatePending: boolean;
+}) {
+	if (!isEditing) return null;
+
+	return (
+		<Group gap="xs" wrap="wrap">
+			<Button
+				color="gray"
+				loading={defaultsPending}
+				onClick={onApplyDefaults}
+				size="xs"
+				style={{ flex: "1 1 11rem" }}
+				variant="default"
+			>
+				Apply class defaults
+			</Button>
+			<Button
+				disabled={disabled}
+				loading={updatePending}
+				onClick={onSaveConfiguration}
+				size="xs"
+				style={{ flex: "1 1 11rem" }}
+				variant="default"
+			>
+				Apply changes
+			</Button>
+		</Group>
+	);
+}

--- a/src/domains/characters/ui/spell-slot-format.test.ts
+++ b/src/domains/characters/ui/spell-slot-format.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { formatSpellLevel, formatSpellSlotChange } from "./spell-slot-format.js";
+import {
+	formatSpellEntryDetail,
+	formatSpellLevel,
+	formatSpellSlotChange,
+} from "./spell-slot-format.js";
 
 describe("spell slot formatting", () => {
 	it("formats spell levels with ordinal suffixes", () => {
@@ -7,6 +11,13 @@ describe("spell slot formatting", () => {
 		expect(formatSpellLevel(2)).toBe("2nd-level");
 		expect(formatSpellLevel(3)).toBe("3rd-level");
 		expect(formatSpellLevel(4)).toBe("4th-level");
+	});
+
+	it("formats cantrip and feature entry details", () => {
+		expect(formatSpellLevel(0)).toBe("cantrip");
+		expect(formatSpellEntryDetail({ level: 0, source: "spell" })).toBe("Cantrip");
+		expect(formatSpellEntryDetail({ level: 1, source: "spell" })).toBe("1st-level spell");
+		expect(formatSpellEntryDetail({ level: 2, source: "feature" })).toBe("2nd-level feature");
 	});
 
 	it("formats spell slot history entries", () => {

--- a/src/domains/characters/ui/spell-slot-format.ts
+++ b/src/domains/characters/ui/spell-slot-format.ts
@@ -10,6 +10,13 @@ export function formatSpellSlotChange(change: SpellSlotChangeResponse) {
 }
 
 export function formatSpellLevel(level: number) {
+	if (level === 0) return "cantrip";
 	const suffix = level === 1 ? "st" : level === 2 ? "nd" : level === 3 ? "rd" : "th";
 	return `${level}${suffix}-level`;
+}
+
+export function formatSpellEntryDetail(entry: { level: number; source: "feature" | "spell" }) {
+	if (entry.source === "feature") return `${formatSpellLevel(entry.level)} feature`;
+	if (entry.level === 0) return "Cantrip";
+	return `${formatSpellLevel(entry.level)} spell`;
 }

--- a/src/domains/characters/ui/spell-slot-list.test.tsx
+++ b/src/domains/characters/ui/spell-slot-list.test.tsx
@@ -10,6 +10,15 @@ describe("SpellSlotList", () => {
 				<SpellSlotList
 					characterSpells={[
 						{
+							id: "00000000-0000-4000-8000-000000000029",
+							slotLevel: 0,
+							spellIndex: "light",
+							name: "Light",
+							level: 0,
+							url: "/api/2014/spells/light",
+							source: "spell",
+						},
+						{
 							id: "00000000-0000-4000-8000-000000000030",
 							slotLevel: 3,
 							spellIndex: "magic-missile",
@@ -43,6 +52,7 @@ describe("SpellSlotList", () => {
 		expect(html).toContain('aria-label="View Magic Missile details"');
 		expect(readableHtml).toContain("Magic Missile");
 		expect(readableHtml).toContain("1st-level spell");
+		expect(readableHtml).not.toContain("Light");
 		expect(readableHtml).toContain("Total 2");
 	});
 

--- a/src/domains/characters/ui/spell-slot-list.tsx
+++ b/src/domains/characters/ui/spell-slot-list.tsx
@@ -2,7 +2,7 @@ import { Anchor, Button, Group, NumberInput, Stack, Text } from "@mantine/core";
 import type { CharacterSpellsResponse } from "../../../generated/api-client.generated.js";
 import type { CharacterSpellSlot } from "../types/index.js";
 import type { NumberDraft } from "./health-dialogs.js";
-import { formatSpellLevel } from "./spell-slot-format.js";
+import { formatSpellEntryDetail, formatSpellLevel } from "./spell-slot-format.js";
 
 interface SpellSlotListProps {
 	characterSpells: CharacterSpellsResponse["spells"];
@@ -117,8 +117,7 @@ export function SpellSlotList({
 												{spell.name}
 											</Anchor>
 											<Text c="dimmed" size="xs">
-												{formatSpellLevel(spell.level)}{" "}
-												{spell.source === "feature" ? "feature" : "spell"}
+												{formatSpellEntryDetail(spell)}
 											</Text>
 										</Stack>
 										{isEditing && (

--- a/src/domains/characters/ui/spell-slot-panel-alerts.test.tsx
+++ b/src/domains/characters/ui/spell-slot-panel-alerts.test.tsx
@@ -1,0 +1,24 @@
+import { MantineProvider } from "@mantine/core";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { SpellSlotPanelAlerts } from "./spell-slot-panel-alerts.js";
+
+describe("SpellSlotPanelAlerts", () => {
+	it("renders spell slot and spell unavailable alerts independently", () => {
+		const html = renderToString(
+			<MantineProvider>
+				<SpellSlotPanelAlerts spellSlotsUnavailable={true} spellsUnavailable={true} />
+			</MantineProvider>,
+		);
+		const hiddenHtml = renderToString(
+			<MantineProvider>
+				<SpellSlotPanelAlerts spellSlotsUnavailable={false} spellsUnavailable={false} />
+			</MantineProvider>,
+		);
+
+		expect(html).toContain("Spell slots unavailable");
+		expect(html).toContain("Spells unavailable");
+		expect(hiddenHtml).not.toContain("Spell slots unavailable");
+		expect(hiddenHtml).not.toContain("Spells unavailable");
+	});
+});

--- a/src/domains/characters/ui/spell-slot-panel-alerts.tsx
+++ b/src/domains/characters/ui/spell-slot-panel-alerts.tsx
@@ -1,0 +1,24 @@
+import { Alert } from "@mantine/core";
+
+export function SpellSlotPanelAlerts({
+	spellSlotsUnavailable,
+	spellsUnavailable,
+}: {
+	spellSlotsUnavailable: boolean;
+	spellsUnavailable: boolean;
+}) {
+	return (
+		<>
+			{spellSlotsUnavailable && (
+				<Alert color="red" title="Spell slots unavailable" variant="light">
+					Try the spell slot change again.
+				</Alert>
+			)}
+			{spellsUnavailable && (
+				<Alert color="red" title="Spells unavailable" variant="light">
+					Try the spell change again.
+				</Alert>
+			)}
+		</>
+	);
+}

--- a/src/domains/characters/ui/spell-slot-panel.test.tsx
+++ b/src/domains/characters/ui/spell-slot-panel.test.tsx
@@ -30,6 +30,15 @@ describe("CharacterSpellSlotsPanel", () => {
 		queryClient.setQueryData(apiQueryKeys.listCharacterSpells({ characterId }), {
 			spells: [
 				{
+					id: "00000000-0000-4000-8000-000000000029",
+					slotLevel: 0,
+					spellIndex: "light",
+					name: "Light",
+					level: 0,
+					url: "/api/2014/spells/light",
+					source: "spell",
+				},
+				{
 					id: "00000000-0000-4000-8000-000000000030",
 					slotLevel: 2,
 					spellIndex: "magic-missile",
@@ -52,6 +61,10 @@ describe("CharacterSpellSlotsPanel", () => {
 		const readableHtml = html.replaceAll("<!-- -->", "");
 		expect(readableHtml).toContain("Spell slots");
 		expect(readableHtml).toContain("Default profile: tier 7");
+		expect(readableHtml).toContain("Cantrips &amp; features");
+		expect(html).toContain('aria-label="Add cantrip or feature"');
+		expect(readableHtml).toContain("Light");
+		expect(readableHtml).toContain("Cantrip");
 		expect(readableHtml).toContain("1st-level");
 		expect(readableHtml).toContain("1 / 2 remaining");
 		expect(readableHtml).toContain("Total 2");

--- a/src/domains/characters/ui/spell-slot-panel.tsx
+++ b/src/domains/characters/ui/spell-slot-panel.tsx
@@ -1,4 +1,4 @@
-import { Alert, Anchor, Button, Divider, Group, Stack, Text, Title } from "@mantine/core";
+import { Anchor, Button, Divider, Group, Stack, Text, Title } from "@mantine/core";
 import { useDebouncedValue } from "@mantine/hooks";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
@@ -14,11 +14,14 @@ import {
 } from "../../../generated/api-client.generated.js";
 import type { CharacterSpellSlot } from "../types/index.js";
 import type { NumberDraft } from "./health-dialogs.js";
+import { NonSlotSpellList } from "./non-slot-spell-list.js";
 import { SpellDetailsModal } from "./spell-details-modal.js";
 import { SpellRemoveModal } from "./spell-remove-modal.js";
 import { SpellSearchModal, type SpellSearchResult } from "./spell-search-modal.js";
+import { SpellSlotEditActions } from "./spell-slot-edit-actions.js";
 import { SpellSlotHistory } from "./spell-slot-history.js";
 import { SpellSlotList } from "./spell-slot-list.js";
+import { SpellSlotPanelAlerts } from "./spell-slot-panel-alerts.js";
 
 interface SpellSearchState {
 	query: string;
@@ -45,6 +48,8 @@ export function CharacterSpellSlotsPanel({
 	const queryClient = useQueryClient();
 	const spellSlots = spellSlotsQuery.data?.spellSlots ?? [];
 	const characterSpells = characterSpellsQuery.data?.spells ?? [];
+	const nonSlotSpells = characterSpells.filter((spell) => spell.slotLevel === 0);
+	const numberedSpells = characterSpells.filter((spell) => spell.slotLevel > 0);
 	const spellSearchInputText = spellSearch?.query.trim() ?? "";
 	const [debouncedSpellSearchInputText] = useDebouncedValue(spellSearchInputText, 300);
 	const spellSearchQueryText =
@@ -106,6 +111,20 @@ export function CharacterSpellSlotsPanel({
 			setSpellToRemove(null);
 		},
 	});
+	const spellSlotsUnavailable = Boolean(
+		spellSlotsQuery.error ||
+			updateMutation.error ||
+			expendMutation.error ||
+			restoreMutation.error ||
+			defaultsMutation.error,
+	);
+	const spellsUnavailable = Boolean(
+		characterSpellsQuery.error ||
+			spellSearchQuery.error ||
+			spellDetailsQuery.error ||
+			removeSpellMutation.error ||
+			saveSpellMutation.error,
+	);
 
 	function setDraftTotal(slotLevel: number, value: NumberDraft) {
 		setDraftTotals((current) => ({ ...current, [slotLevel]: value }));
@@ -209,33 +228,25 @@ export function CharacterSpellSlotsPanel({
 				opened={historyOpen}
 			/>
 
-			{isEditing && (
-				<Group gap="xs" wrap="wrap">
-					<Button
-						color="gray"
-						loading={defaultsMutation.isPending}
-						onClick={applyDefaults}
-						size="xs"
-						style={{ flex: "1 1 11rem" }}
-						variant="default"
-					>
-						Apply class defaults
-					</Button>
-					<Button
-						disabled={spellSlots.length === 0}
-						loading={updateMutation.isPending}
-						onClick={saveConfiguration}
-						size="xs"
-						style={{ flex: "1 1 11rem" }}
-						variant="default"
-					>
-						Apply changes
-					</Button>
-				</Group>
-			)}
+			<SpellSlotEditActions
+				defaultsPending={defaultsMutation.isPending}
+				disabled={spellSlots.length === 0}
+				isEditing={isEditing}
+				onApplyDefaults={applyDefaults}
+				onSaveConfiguration={saveConfiguration}
+				updatePending={updateMutation.isPending}
+			/>
+
+			<NonSlotSpellList
+				characterSpells={nonSlotSpells}
+				isEditing={isEditing}
+				onOpenSpellDetails={(spell) => setSelectedSpellId(spell.id)}
+				onOpenSpellSearch={() => openSpellSearch(0)}
+				onRemoveSpell={setSpellToRemove}
+			/>
 
 			<SpellSlotList
-				characterSpells={characterSpells}
+				characterSpells={numberedSpells}
 				draftTotals={draftTotals}
 				isEditing={isEditing}
 				onDraftTotalChange={setDraftTotal}
@@ -247,24 +258,10 @@ export function CharacterSpellSlotsPanel({
 				spellSlots={spellSlots}
 			/>
 
-			{(spellSlotsQuery.error ||
-				updateMutation.error ||
-				expendMutation.error ||
-				restoreMutation.error ||
-				defaultsMutation.error) && (
-				<Alert color="red" title="Spell slots unavailable" variant="light">
-					Try the spell slot change again.
-				</Alert>
-			)}
-			{(characterSpellsQuery.error ||
-				spellSearchQuery.error ||
-				spellDetailsQuery.error ||
-				removeSpellMutation.error ||
-				saveSpellMutation.error) && (
-				<Alert color="red" title="Spells unavailable" variant="light">
-					Try the spell change again.
-				</Alert>
-			)}
+			<SpellSlotPanelAlerts
+				spellSlotsUnavailable={spellSlotsUnavailable}
+				spellsUnavailable={spellsUnavailable}
+			/>
 
 			<SpellSearchModal
 				onChangeQuery={updateSpellSearchQuery}

--- a/src/generated/openapi.generated.json
+++ b/src/generated/openapi.generated.json
@@ -2393,7 +2393,7 @@
 													},
 													"slotLevel": {
 														"type": "integer",
-														"minimum": 1,
+														"minimum": 0,
 														"maximum": 9
 													},
 													"spellIndex": {
@@ -2410,7 +2410,7 @@
 													},
 													"level": {
 														"type": "integer",
-														"minimum": 1,
+														"minimum": 0,
 														"maximum": 20
 													},
 													"url": {
@@ -2497,7 +2497,7 @@
 								"properties": {
 									"slotLevel": {
 										"type": "integer",
-										"minimum": 1,
+										"minimum": 0,
 										"maximum": 9
 									},
 									"spellIndex": {
@@ -2545,7 +2545,7 @@
 													},
 													"slotLevel": {
 														"type": "integer",
-														"minimum": 1,
+														"minimum": 0,
 														"maximum": 9
 													},
 													"spellIndex": {
@@ -2562,7 +2562,7 @@
 													},
 													"level": {
 														"type": "integer",
-														"minimum": 1,
+														"minimum": 0,
 														"maximum": 20
 													},
 													"url": {
@@ -2708,7 +2708,7 @@
 												},
 												"slotLevel": {
 													"type": "integer",
-													"minimum": 1,
+													"minimum": 0,
 													"maximum": 9
 												},
 												"spellIndex": {
@@ -2725,7 +2725,7 @@
 												},
 												"level": {
 													"type": "integer",
-													"minimum": 1,
+													"minimum": 0,
 													"maximum": 20
 												},
 												"url": {
@@ -2897,7 +2897,7 @@
 													},
 													"slotLevel": {
 														"type": "integer",
-														"minimum": 1,
+														"minimum": 0,
 														"maximum": 9
 													},
 													"spellIndex": {
@@ -2914,7 +2914,7 @@
 													},
 													"level": {
 														"type": "integer",
-														"minimum": 1,
+														"minimum": 0,
 														"maximum": 20
 													},
 													"url": {
@@ -3003,7 +3003,7 @@
 								"properties": {
 									"slotLevel": {
 										"type": "integer",
-										"minimum": 1,
+										"minimum": 0,
 										"maximum": 9
 									},
 									"query": {
@@ -3047,7 +3047,7 @@
 													},
 													"level": {
 														"type": "integer",
-														"minimum": 1,
+														"minimum": 0,
 														"maximum": 20
 													},
 													"url": {

--- a/tests/e2e/character-health-flow.spec.ts
+++ b/tests/e2e/character-health-flow.spec.ts
@@ -67,8 +67,31 @@ test("configures spell slots and tracks spell usage on detail", async ({ page })
 
 	await expect(page.getByRole("heading", { name: "Tamsin" })).toBeVisible();
 	await expect(page.getByRole("heading", { name: "Spell slots" })).toBeVisible();
+	await expect(page.getByText("Cantrips & features")).toBeVisible();
 	await expect(page.getByText("0 / 0 remaining").first()).toBeHidden();
 	await expect(page.getByLabel("1st-level slot total")).toBeHidden();
+
+	await page.getByRole("button", { name: "Add cantrip or feature" }).click();
+	await expect(page.getByRole("dialog", { name: "Add cantrip or feature" })).toBeVisible();
+	await page.getByLabel("Search cantrips and features").fill("light");
+	await expect(page.getByRole("button", { name: /^Light\b/ })).toBeVisible({
+		timeout: spellApiTimeoutMs,
+	});
+	await page.getByRole("button", { name: /^Light\b/ }).click();
+	await expect(page.getByRole("dialog", { name: "Add cantrip or feature" })).toBeHidden();
+	await expect(page.getByRole("button", { name: "View Light details" })).toBeVisible();
+	await expect(page.getByText("Cantrip", { exact: true })).toBeVisible();
+	await page.getByRole("button", { name: "Add cantrip or feature" }).click();
+	await page.getByLabel("Search cantrips and features").fill("lay on hands");
+	await expect(page.getByRole("button", { name: /^Lay on Hands\b/ })).toBeVisible({
+		timeout: spellApiTimeoutMs,
+	});
+	await page.getByRole("button", { name: /^Lay on Hands\b/ }).click();
+	await expect(page.getByRole("dialog", { name: "Add cantrip or feature" })).toBeHidden({
+		timeout: spellApiTimeoutMs,
+	});
+	await expect(page.getByRole("button", { name: "View Lay on Hands details" })).toBeVisible();
+	await expect(page.getByText("1st-level feature")).toBeVisible();
 
 	await page.getByRole("button", { name: /Spell history/ }).click();
 	await expect(page.getByText("No spell slot changes yet.")).toBeVisible();
@@ -172,6 +195,8 @@ test("configures spell slots and tracks spell usage on detail", async ({ page })
 
 	await page.reload();
 	await expect(page.getByText("2 / 2 remaining")).toBeVisible();
+	await expect(page.getByText("Light")).toBeVisible();
+	await expect(page.getByText("Lay on Hands")).toBeVisible();
 	await expect(page.getByText("Divine Smite")).toBeVisible();
 	await expect(page.getByText("Restored 1st-level slot")).toBeHidden();
 	await page.getByRole("button", { name: /Spell history/ }).click();


### PR DESCRIPTION
## Summary
- add a non-slot saved spell bucket for cantrips and class features
- render a separate Cantrips & features section without spell slot use/restore controls
- keep numbered spell slots for leveled spells and update search/save validation
- add migration, generated OpenAPI updates, unit/integration/runtime/e2e coverage, and quality notes

## Validation
- pnpm lint
- pnpm api:check
- pnpm test
- pnpm check:docs

## Notes
- Feature spec docs are intentionally excluded from this PR.