### PR TITLE
Fix add spell dialog mobile focus

### DIFF
--- a/docs/quality.md
+++ b/docs/quality.md
@@ -14,7 +14,7 @@ Track the health of each domain and architectural layer. Update this when you im
 
 | Domain | Types | Config | Repo | Service | Runtime | UI | Overall | Notes |
 |--------|-------|--------|------|---------|---------|----|---------|----|
-| characters | B | B | B | B | B | B | B | Character create/list/detail, detail-page health tracking, spell slot tracking, add-spell dialog focus/mobile input sizing, and saved spell details have unit, integration, route, generated-client, and e2e coverage |
+| characters | B | B | B | B | B | B | B | Character create/list/detail, detail-page health tracking, spell slot tracking, mobile-safe editable input sizing, add-spell dialog focus, and saved spell details have unit, integration, route, generated-client, and e2e coverage |
 
 ## Cross-Cutting
 

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -14,7 +14,7 @@ Track the health of each domain and architectural layer. Update this when you im
 
 | Domain | Types | Config | Repo | Service | Runtime | UI | Overall | Notes |
 |--------|-------|--------|------|---------|---------|----|---------|----|
-| characters | B | B | B | B | B | B | B | Character create/list/detail, detail-page health tracking, spell slot tracking, and saved spell details have unit, integration, route, generated-client, and e2e coverage |
+| characters | B | B | B | B | B | B | B | Character create/list/detail, detail-page health tracking, spell slot tracking, add-spell dialog focus/mobile input sizing, and saved spell details have unit, integration, route, generated-client, and e2e coverage |
 
 ## Cross-Cutting
 

--- a/src/app/theme.test.ts
+++ b/src/app/theme.test.ts
@@ -8,4 +8,19 @@ describe("theme", () => {
 		expect(theme.colors?.candle).toHaveLength(10);
 		expect(theme.defaultRadius).toBe("sm");
 	});
+
+	it("keeps editable controls at mobile-safe sizing", () => {
+		expect(theme.components?.TextInput?.defaultProps).toMatchObject({
+			radius: "sm",
+			size: "md",
+		});
+		expect(theme.components?.NumberInput?.defaultProps).toMatchObject({
+			radius: "sm",
+			size: "md",
+		});
+		expect(theme.components?.Select?.defaultProps).toMatchObject({
+			radius: "sm",
+			size: "md",
+		});
+	});
 });

--- a/src/app/theme.ts
+++ b/src/app/theme.ts
@@ -59,6 +59,19 @@ export const theme = createTheme({
 		TextInput: {
 			defaultProps: {
 				radius: "sm",
+				size: "md",
+			},
+		},
+		NumberInput: {
+			defaultProps: {
+				radius: "sm",
+				size: "md",
+			},
+		},
+		Select: {
+			defaultProps: {
+				radius: "sm",
+				size: "md",
 			},
 		},
 	},

--- a/src/domains/characters/ui/health-dialogs.tsx
+++ b/src/domains/characters/ui/health-dialogs.tsx
@@ -34,7 +34,6 @@ export function HealthAmountModal({
 					<NumberInput
 						allowDecimal={false}
 						allowNegative={false}
-						autoFocus
 						data-autofocus
 						hideControls
 						label="Amount"

--- a/src/domains/characters/ui/spell-search-modal.tsx
+++ b/src/domains/characters/ui/spell-search-modal.tsx
@@ -29,6 +29,7 @@ export function SpellSearchModal({
 }) {
 	return (
 		<Modal
+			closeButtonProps={{ "aria-label": "Close add spell dialog", size: "xl", variant: "light" }}
 			fullScreen
 			onClose={onClose}
 			opened={opened}
@@ -38,9 +39,12 @@ export function SpellSearchModal({
 		>
 			<Stack gap="md">
 				<TextInput
+					autoFocus
+					data-autofocus
 					label="Search spells"
 					onChange={(event) => onChangeQuery(event.currentTarget.value)}
 					placeholder="Spell name"
+					size="md"
 					value={query}
 				/>
 

--- a/src/domains/characters/ui/spell-search-modal.tsx
+++ b/src/domains/characters/ui/spell-search-modal.tsx
@@ -39,7 +39,6 @@ export function SpellSearchModal({
 		>
 			<Stack gap="md">
 				<TextInput
-					autoFocus
 					data-autofocus
 					label="Search spells"
 					onChange={(event) => onChangeQuery(event.currentTarget.value)}

--- a/src/domains/characters/ui/spell-search-modal.tsx
+++ b/src/domains/characters/ui/spell-search-modal.tsx
@@ -29,7 +29,7 @@ export function SpellSearchModal({
 }) {
 	return (
 		<Modal
-			closeButtonProps={{ "aria-label": "Close add spell dialog", size: "xl", variant: "light" }}
+			closeButtonProps={{ "aria-label": "Close add spell dialog", size: "xl" }}
 			fullScreen
 			onClose={onClose}
 			opened={opened}

--- a/src/domains/characters/ui/spell-slot-list.tsx
+++ b/src/domains/characters/ui/spell-slot-list.tsx
@@ -70,7 +70,6 @@ export function SpellSlotList({
 									label={`${formatSpellLevel(slot.level)} slot total`}
 									min={0}
 									onChange={(value) => onDraftTotalChange(slot.level, toDraft(value))}
-									size="xs"
 									style={{ flex: "1 1 7rem" }}
 									value={draftTotals[slot.level] ?? slot.total}
 								/>

--- a/tests/e2e/character-creation.spec.ts
+++ b/tests/e2e/character-creation.spec.ts
@@ -10,6 +10,9 @@ test("creates a character, lists it, opens detail, and persists across reloads",
 
 	await page.getByText("Create character").first().click();
 	await expect(page).toHaveURL(/\/characters\/new$/);
+	await expect(page.getByLabel("Name")).toHaveCSS("font-size", "16px");
+	await expect(page.getByRole("combobox", { name: "Class" })).toHaveCSS("font-size", "16px");
+	await expect(page.getByLabel("Level")).toHaveCSS("font-size", "16px");
 
 	await page.getByRole("button", { name: "Create character" }).click();
 	await expect(page.getByText("Name is required")).toBeVisible();

--- a/tests/e2e/character-health-flow.spec.ts
+++ b/tests/e2e/character-health-flow.spec.ts
@@ -81,7 +81,18 @@ test("configures spell slots and tracks spell usage on detail", async ({ page })
 
 	await page.getByRole("button", { name: "Edit spells" }).click();
 	await page.getByRole("button", { name: "Add spell to 3rd-level" }).click();
-	await expect(page.getByRole("dialog", { name: "Add spell to 3rd-level" })).toBeVisible();
+	let addSpellDialog = page.getByRole("dialog", { name: "Add spell to 3rd-level" });
+	await expect(addSpellDialog).toBeVisible();
+	await expect(
+		addSpellDialog.getByRole("button", { name: "Close add spell dialog" }),
+	).toBeVisible();
+	let closeButtonBox = await addSpellDialog
+		.getByRole("button", { name: "Close add spell dialog" })
+		.boundingBox();
+	expect(closeButtonBox?.width ?? 0).toBeGreaterThanOrEqual(44);
+	expect(closeButtonBox?.height ?? 0).toBeGreaterThanOrEqual(44);
+	await expect(page.getByLabel("Search spells")).toBeFocused();
+	await expect(page.getByLabel("Search spells")).toHaveCSS("font-size", "16px");
 	await page.getByLabel("Search spells").fill("haste");
 	await expect(page.getByRole("button", { name: /Haste/ })).toBeVisible();
 	await page.getByLabel("Search spells").fill("divine smite");
@@ -89,6 +100,21 @@ test("configures spell slots and tracks spell usage on detail", async ({ page })
 	await expect(page.getByRole("dialog", { name: "Add spell to 3rd-level" })).toBeHidden();
 	await expect(page.getByRole("button", { name: "View Divine Smite details" })).toBeVisible();
 	await expect(page.getByText("2nd-level feature")).toBeVisible();
+	await page.getByRole("button", { name: "Add spell to 3rd-level" }).click();
+	addSpellDialog = page.getByRole("dialog", { name: "Add spell to 3rd-level" });
+	await expect(addSpellDialog).toBeVisible();
+	await expect(
+		addSpellDialog.getByRole("button", { name: "Close add spell dialog" }),
+	).toBeVisible();
+	closeButtonBox = await addSpellDialog
+		.getByRole("button", { name: "Close add spell dialog" })
+		.boundingBox();
+	expect(closeButtonBox?.width ?? 0).toBeGreaterThanOrEqual(44);
+	expect(closeButtonBox?.height ?? 0).toBeGreaterThanOrEqual(44);
+	await expect(page.getByLabel("Search spells")).toBeFocused();
+	await expect(page.getByLabel("Search spells")).toHaveCSS("font-size", "16px");
+	await addSpellDialog.getByRole("button", { name: "Close add spell dialog" }).click();
+	await expect(addSpellDialog).toBeHidden();
 	await page.getByRole("button", { name: "View Divine Smite details" }).click();
 	await expect(page.getByRole("dialog", { name: "Divine Smite" })).toBeVisible();
 	await expect(page.getByText("Feature 2nd-level")).toBeVisible();

--- a/tests/e2e/character-health-flow.spec.ts
+++ b/tests/e2e/character-health-flow.spec.ts
@@ -15,6 +15,8 @@ test("creates a character and tracks health changes on detail", async ({ page })
 	await expect(page.getByText("HP +5, Temp HP +5")).toBeHidden();
 
 	await page.getByRole("button", { exact: true, name: "Edit" }).click();
+	await expect(page.getByLabel("Max HP")).toHaveCSS("font-size", "16px");
+	await expect(page.getByLabel("Temp HP")).toHaveCSS("font-size", "16px");
 	await page.getByLabel("Temp HP").fill("5");
 	await page.getByRole("button", { name: "Save" }).click();
 	await expect(page.getByText("15 / 15 HP (Temp HP +5)")).toBeVisible();
@@ -24,10 +26,12 @@ test("creates a character and tracks health changes on detail", async ({ page })
 
 	await page.getByRole("button", { name: "Heal" }).click();
 	await expect(page.getByLabel("Amount")).toBeFocused();
+	await expect(page.getByLabel("Amount")).toHaveCSS("font-size", "16px");
 	await page.getByRole("button", { name: "Cancel" }).click();
 
 	await page.getByRole("button", { name: "Damage" }).click();
 	await expect(page.getByLabel("Amount")).toBeFocused();
+	await expect(page.getByLabel("Amount")).toHaveCSS("font-size", "16px");
 	await page.getByLabel("Amount").fill("4");
 	await page.getByRole("button", { name: "Save" }).click();
 	await expect(page.getByText("11 / 15 HP (Temp HP +5)")).toBeVisible();
@@ -68,6 +72,7 @@ test("configures spell slots and tracks spell usage on detail", async ({ page })
 	await page.getByRole("button", { name: /Spell history/ }).click();
 
 	await page.getByRole("button", { name: "Edit spells" }).click();
+	await expect(page.getByLabel("1st-level slot total")).toHaveCSS("font-size", "16px");
 	await page.getByLabel("1st-level slot total").fill("2");
 	await page.getByRole("button", { name: "Apply changes" }).click();
 	await expect(page.getByText("2 / 2 remaining")).toBeVisible();


### PR DESCRIPTION
## Summary
- make the add-spell dialog close control accessible, larger, and easier to hit on mobile
- focus the spell search field when the dialog opens
- render the spell search input at 16px to avoid iOS Safari input zoom
- add e2e coverage for close affordance, focus, and mobile input sizing

## Validation
- pnpm lint
- pnpm api:check
- pnpm test
- pnpm check:docs