### PR TITLE
Add local production deploy workflow

### DIFF
--- a/.github/workflows/deploy-local-production.yml
+++ b/.github/workflows/deploy-local-production.yml
@@ -1,0 +1,77 @@
+name: Deploy Local Production
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dnd-character-manager-local-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: [self-hosted, dev-server-1, dnd-character-manager, production]
+    environment: local-production
+    timeout-minutes: 20
+
+    steps:
+      - name: Resolve deployment revision
+        id: revision
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            deploy_sha="${{ github.event.workflow_run.head_sha }}"
+          else
+            deploy_sha="${{ github.sha }}"
+          fi
+
+          if [ -z "$deploy_sha" ]; then
+            echo "::error::Could not resolve deployment revision."
+            exit 1
+          fi
+
+          printf 'sha=%s\n' "$deploy_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy exact revision through host Docker
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          deploy_sha="${{ steps.revision.outputs.sha }}"
+          workspace="/home/sbolgert/workspace/dnd-character-manager"
+          compose=(docker compose --env-file .env.production -f docker-compose.prod.yml)
+
+          cd "$workspace"
+
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::Production workspace has uncommitted changes; refusing to deploy."
+            git status --short
+            exit 1
+          fi
+
+          git fetch --prune origin
+          git checkout --detach "$deploy_sha"
+
+          "${compose[@]}" up -d --build
+
+          for _ in {1..12}; do
+            if "${compose[@]}" exec -T app node -e "fetch('http://127.0.0.1:4000/healthz').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"; then
+              break
+            fi
+
+            sleep 5
+          done
+
+          "${compose[@]}" exec -T app node -e "fetch('http://127.0.0.1:4000/healthz').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+          "${compose[@]}" exec -T app node -e "fetch('http://127.0.0.1:4000/openapi.json').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+          curl --fail --retry 6 --retry-delay 5 -I https://characters.dndinventorymanager.com
+

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -135,6 +135,15 @@ curl -I https://characters.dndinventorymanager.com
 
 Use this when the tunnel route and host service already exist.
 
+The preferred routine path is the `Deploy Local Production` GitHub Actions workflow. It runs on the
+`dev-server-1` self-hosted runner after `CI` succeeds on `main`, checks out the exact commit in
+`/home/sbolgert/workspace/dnd-character-manager`, rebuilds the production Compose stack through the
+host Docker socket, and verifies the app container plus public hostname. The production workspace
+must be clean; the workflow refuses to deploy over uncommitted local changes.
+
+Use the manual shell path below for first deployment, rollback, or when GitHub Actions is
+unavailable.
+
 1. Pull or checkout the intended revision in `/home/sbolgert/workspace/dnd-character-manager`.
 2. Run validation locally.
 3. Restart the production service:
@@ -231,4 +240,3 @@ Inspect containers:
 ```bash
 docker compose --env-file .env.production -f docker-compose.prod.yml ps
 ```
-


### PR DESCRIPTION
## Summary
- add a `Deploy Local Production` workflow that runs on the `dev-server-1` self-hosted runner after CI succeeds on `main`
- deploy the exact validated revision through host Docker Compose
- document the CI-triggered deployment path and clean-workspace guard

## Validation
- `pnpm lint`
- `pnpm check:docs`
- `pnpm test:unit`

## Notes
The workflow refuses to deploy if `/home/sbolgert/workspace/dnd-character-manager` has uncommitted changes. The current host workspace still has unrelated local MVP doc edits that are intentionally not included in this PR.