### PR TITLE
Fix local deploy workflow fetch

### DIFF
--- a/.github/workflows/deploy-local-production.yml
+++ b/.github/workflows/deploy-local-production.yml
@@ -43,6 +43,8 @@ jobs:
 
       - name: Deploy exact revision through host Docker
         shell: bash
+        env:
+          GH_FETCH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -58,7 +60,7 @@ jobs:
             exit 1
           fi
 
-          git fetch --prune origin
+          git fetch "https://x-access-token:${GH_FETCH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "+refs/heads/*:refs/remotes/origin/*"
           git checkout --detach "$deploy_sha"
 
           "${compose[@]}" up -d --build
@@ -74,4 +76,3 @@ jobs:
           "${compose[@]}" exec -T app node -e "fetch('http://127.0.0.1:4000/healthz').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
           "${compose[@]}" exec -T app node -e "fetch('http://127.0.0.1:4000/openapi.json').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
           curl --fail --retry 6 --retry-delay 5 -I https://characters.dndinventorymanager.com
-


### PR DESCRIPTION
## Summary
- fetch the production revision over HTTPS with the workflow token instead of using the host repository SSH remote
- avoid requiring SSH known_hosts or private keys inside the Dockerized self-hosted runner

## Root cause
The first deploy run failed at `git fetch --prune origin` because the Dockerized runner executed inside a container without GitHub SSH host trust/key material, while the production checkout uses an SSH origin remote.

## Validation
- `pnpm lint`
- `pnpm check:docs`
- manual production deploy of merge commit `46f403c` succeeded and health checks passed