### PR TITLE
feat: remove character spells

### DIFF
--- a/docs/quality.md
+++ b/docs/quality.md
@@ -14,7 +14,7 @@ Track the health of each domain and architectural layer. Update this when you im
 
 | Domain | Types | Config | Repo | Service | Runtime | UI | Overall | Notes |
 |--------|-------|--------|------|---------|---------|----|---------|----|
-| characters | B | B | B | B | B | B | B | Character create/list/detail, detail-page health tracking, spell slot tracking, mobile-safe editable input sizing, add-spell dialog focus, and saved spell details have unit, integration, route, generated-client, and e2e coverage |
+| characters | B | B | B | B | B | B | B | Character create/list/detail, detail-page health tracking, spell slot tracking, mobile-safe editable input sizing, add/remove-spell flows, and saved spell details have unit, integration, route, generated-client, and e2e coverage |
 
 ## Cross-Cutting
 

--- a/src/api-contracts.test.ts
+++ b/src/api-contracts.test.ts
@@ -18,6 +18,7 @@ describe("apiRouteContracts", () => {
 			"getCharacterSpellDetails",
 			"searchCharacterSpells",
 			"saveCharacterSpell",
+			"removeCharacterSpell",
 		]);
 		expect(apiRouteContracts.every((route) => route.path.startsWith("/api/"))).toBe(true);
 	});

--- a/src/domains/characters/repo/character-spell-repository.integration.test.ts
+++ b/src/domains/characters/repo/character-spell-repository.integration.test.ts
@@ -87,6 +87,17 @@ describe("createCharacterSpellRepository", () => {
 			expect.objectContaining({ spellIndex: "magic-missile" }),
 			expect.objectContaining({ spellIndex: "acid-arrow" }),
 		]);
+		await expect(
+			repository.removeCharacterSpell(crypto.randomUUID(), character.id, savedSpellId),
+		).resolves.toBeNull();
+		await expect(
+			repository.removeCharacterSpell(userId, character.id, savedSpellId),
+		).resolves.toEqual({
+			spells: [expect.objectContaining({ spellIndex: "acid-arrow" })],
+		});
+		await expect(
+			repository.getCharacterSpell(userId, character.id, savedSpellId),
+		).resolves.toBeNull();
 	});
 
 	it("persists high-level class features saved under a spell slot", async () => {

--- a/src/domains/characters/repo/character-spell-repository.ts
+++ b/src/domains/characters/repo/character-spell-repository.ts
@@ -27,6 +27,11 @@ export interface CharacterSpellRepository {
 		characterId: string,
 		spell: NewCharacterSpell,
 	): Promise<CharacterSpellsResponse | null>;
+	removeCharacterSpell(
+		userId: string,
+		characterId: string,
+		spellId: string,
+	): Promise<CharacterSpellsResponse | null>;
 }
 
 export function createCharacterSpellRepository(): CharacterSpellRepository {
@@ -96,6 +101,23 @@ export function createCharacterSpellRepository(): CharacterSpellRepository {
 						characterSpellsTable.spellIndex,
 					],
 				});
+
+			const spells = await this.listCharacterSpells(userId, characterId);
+			if (!spells) return null;
+			return CharacterSpellsResponseSchema.parse({ spells });
+		},
+
+		async removeCharacterSpell(userId, characterId, spellId) {
+			if (!(await this.characterExists(userId, characterId))) return null;
+
+			await getDb()
+				.delete(characterSpellsTable)
+				.where(
+					and(
+						eq(characterSpellsTable.characterId, characterId),
+						eq(characterSpellsTable.id, spellId),
+					),
+				);
 
 			const spells = await this.listCharacterSpells(userId, characterId);
 			if (!spells) return null;

--- a/src/domains/characters/runtime/character-spell-contracts.test.ts
+++ b/src/domains/characters/runtime/character-spell-contracts.test.ts
@@ -8,12 +8,14 @@ describe("characterSpellRouteContracts", () => {
 			"getCharacterSpellDetails",
 			"searchCharacterSpells",
 			"saveCharacterSpell",
+			"removeCharacterSpell",
 		]);
 		expect(characterSpellRouteContracts.map((route) => route.client?.functionName)).toEqual([
 			"listCharacterSpells",
 			"getCharacterSpellDetails",
 			"searchCharacterSpells",
 			"saveCharacterSpell",
+			"removeCharacterSpell",
 		]);
 	});
 

--- a/src/domains/characters/runtime/character-spell-contracts.ts
+++ b/src/domains/characters/runtime/character-spell-contracts.ts
@@ -112,4 +112,26 @@ export const characterSpellRouteContracts = [
 			responseType: "CharacterSpellsResponse",
 		},
 	},
+	{
+		method: "delete",
+		operationId: "removeCharacterSpell",
+		path: "/api/characters/:characterId/spells/:spellId",
+		pathParams: CharacterSpellPathParamsSchema,
+		responses: {
+			200: {
+				description: "Updated saved character spells",
+				schema: CharacterSpellsResponseSchema,
+			},
+			404: { description: "Character not found", schema: ErrorResponseSchema },
+		},
+		summary: "Remove character spell",
+		tags: ["characters"],
+		client: {
+			functionName: "removeCharacterSpell",
+			imports: [...characterTypeImports, ...characterSchemaImports],
+			pathParamsType: "{ characterId: string; spellId: string }",
+			responseParser: "CharacterSpellsResponseSchema",
+			responseType: "CharacterSpellsResponse",
+		},
+	},
 ] as const satisfies readonly ApiRouteContract[];

--- a/src/domains/characters/runtime/contract.test.ts
+++ b/src/domains/characters/runtime/contract.test.ts
@@ -17,6 +17,7 @@ describe("characterRouteContracts", () => {
 			"getCharacterSpellDetails",
 			"searchCharacterSpells",
 			"saveCharacterSpell",
+			"removeCharacterSpell",
 		]);
 		expect(characterRouteContracts.map((route) => route.client?.functionName)).toEqual([
 			"createCharacter",
@@ -32,13 +33,14 @@ describe("characterRouteContracts", () => {
 			"getCharacterSpellDetails",
 			"searchCharacterSpells",
 			"saveCharacterSpell",
+			"removeCharacterSpell",
 		]);
 	});
 
 	it("uses characterId path params for detail, health, and spell slot routes", () => {
 		const routeWithParams = characterRouteContracts.filter((route) => route.path.includes(":"));
 
-		expect(routeWithParams).toHaveLength(11);
+		expect(routeWithParams).toHaveLength(12);
 		expect(routeWithParams.every((route) => "pathParams" in route)).toBe(true);
 	});
 });

--- a/src/domains/characters/runtime/routes.spells.test.ts
+++ b/src/domains/characters/runtime/routes.spells.test.ts
@@ -69,6 +69,7 @@ describe("registerCharacterRoutes spell routes", () => {
 		services.characterSpellService.getCharacterSpellDetails.mockResolvedValue(details);
 		services.characterSpellService.searchCharacterSpells.mockResolvedValue(search);
 		services.characterSpellService.saveCharacterSpell.mockResolvedValue(spells);
+		services.characterSpellService.removeCharacterSpell.mockResolvedValue({ spells: [] });
 		const app = await buildApp(services);
 
 		try {
@@ -90,11 +91,17 @@ describe("registerCharacterRoutes spell routes", () => {
 				url: `/api/characters/${character.id}/spells`,
 				payload: { slotLevel: 3, spellIndex: "magic-missile", source: "spell" },
 			});
+			const removeResponse = await app.inject({
+				method: "DELETE",
+				url: `/api/characters/${character.id}/spells/00000000-0000-4000-8000-000000000030`,
+			});
 
 			expect(listResponse.json()).toEqual(spells);
 			expect(searchResponse.json()).toEqual(search);
 			expect(detailsResponse.json()).toEqual(details);
 			expect(saveResponse.json()).toEqual(spells);
+			expect(removeResponse.statusCode).toBe(200);
+			expect(removeResponse.json()).toEqual({ spells: [] });
 			expect(services.characterSpellService.getCharacterSpellDetails).toHaveBeenCalledWith(
 				userId,
 				character.id,
@@ -109,6 +116,11 @@ describe("registerCharacterRoutes spell routes", () => {
 				userId,
 				character.id,
 				{ slotLevel: 3, spellIndex: "magic-missile", source: "spell" },
+			);
+			expect(services.characterSpellService.removeCharacterSpell).toHaveBeenCalledWith(
+				userId,
+				character.id,
+				"00000000-0000-4000-8000-000000000030",
 			);
 		} finally {
 			await app.close();
@@ -182,6 +194,7 @@ function fakeSpellService() {
 	return {
 		getCharacterSpellDetails: vi.fn(),
 		listCharacterSpells: vi.fn(),
+		removeCharacterSpell: vi.fn(),
 		saveCharacterSpell: vi.fn(),
 		searchCharacterSpells: vi.fn(),
 	} satisfies CharacterSpellService;

--- a/src/domains/characters/runtime/routes.test.ts
+++ b/src/domains/characters/runtime/routes.test.ts
@@ -275,14 +275,13 @@ function fakeService() {
 }
 
 function fakeHealthService() {
-	return {
-		updateCharacterHealth: vi.fn(),
-	} satisfies CharacterHealthService;
+	return { updateCharacterHealth: vi.fn() } satisfies CharacterHealthService;
 }
 function fakeSpellService() {
 	return {
 		getCharacterSpellDetails: vi.fn(),
 		listCharacterSpells: vi.fn(),
+		removeCharacterSpell: vi.fn(),
 		saveCharacterSpell: vi.fn(),
 		searchCharacterSpells: vi.fn(),
 	} satisfies CharacterSpellService;

--- a/src/domains/characters/runtime/routes.ts
+++ b/src/domains/characters/runtime/routes.ts
@@ -264,4 +264,20 @@ export async function registerCharacterRoutes(
 			return sendSpellError(error, reply);
 		}
 	});
+
+	app.delete("/api/characters/:characterId/spells/:spellId", async (request, reply) => {
+		const params = parseSpellParams(request, reply);
+		if (!params) return;
+
+		const currentUser = await getCurrentUser(request, reply);
+		try {
+			return await characterSpellService.removeCharacterSpell(
+				currentUser.user.id,
+				params.characterId,
+				params.spellId,
+			);
+		} catch (error) {
+			return sendSpellError(error, reply);
+		}
+	});
 }

--- a/src/domains/characters/service/character-spell-service.test.ts
+++ b/src/domains/characters/service/character-spell-service.test.ts
@@ -165,6 +165,21 @@ describe("createCharacterSpellService", () => {
 		expect(spellsClient.getSpellDetails).toHaveBeenCalledWith("magic-missile", "spell");
 	});
 
+	it("removes a saved character spell and returns the updated spell list", async () => {
+		const repository = fakeRepository();
+		repository.removeCharacterSpell.mockResolvedValue({ spells: [] });
+		const service = createCharacterSpellService(repository, fakeSpellsClient());
+
+		await expect(
+			service.removeCharacterSpell("user-1", "character-1", "00000000-0000-4000-8000-000000000030"),
+		).resolves.toEqual({ spells: [] });
+		expect(repository.removeCharacterSpell).toHaveBeenCalledWith(
+			"user-1",
+			"character-1",
+			"00000000-0000-4000-8000-000000000030",
+		);
+	});
+
 	it("rejects saving a spell above the selected slot level", async () => {
 		const repository = fakeRepository();
 		const spellsClient = fakeSpellsClient();
@@ -204,6 +219,9 @@ describe("createCharacterSpellService", () => {
 				source: "spell",
 			}),
 		).rejects.toThrow(CharacterNotFoundError);
+		await expect(
+			service.removeCharacterSpell("user-2", "character-1", "00000000-0000-4000-8000-000000000030"),
+		).rejects.toThrow(CharacterNotFoundError);
 		expect(spellsClient.searchSpells).not.toHaveBeenCalled();
 		expect(spellsClient.findSpell).not.toHaveBeenCalled();
 	});
@@ -214,6 +232,7 @@ function fakeRepository() {
 		characterExists: vi.fn().mockResolvedValue(true),
 		getCharacterSpell: vi.fn(),
 		listCharacterSpells: vi.fn().mockResolvedValue([]),
+		removeCharacterSpell: vi.fn(),
 		saveCharacterSpell: vi.fn(),
 	} satisfies {
 		[K in keyof CharacterSpellRepository]: CharacterSpellRepository[K] extends (

--- a/src/domains/characters/service/character-spell-service.ts
+++ b/src/domains/characters/service/character-spell-service.ts
@@ -38,6 +38,11 @@ export interface CharacterSpellService {
 		characterId: string,
 		input: SaveCharacterSpellRequest,
 	): Promise<CharacterSpellsResponse>;
+	removeCharacterSpell(
+		userId: string,
+		characterId: string,
+		spellId: string,
+	): Promise<CharacterSpellsResponse>;
 }
 
 export function createCharacterSpellService(
@@ -125,6 +130,12 @@ export function createCharacterSpellService(
 				}
 				throw error;
 			}
+		},
+
+		async removeCharacterSpell(userId, characterId, spellId) {
+			const response = await repository.removeCharacterSpell(userId, characterId, spellId);
+			if (!response) throw new CharacterNotFoundError();
+			return response;
 		},
 	};
 }

--- a/src/domains/characters/ui/spell-remove-modal.test.tsx
+++ b/src/domains/characters/ui/spell-remove-modal.test.tsx
@@ -1,0 +1,34 @@
+import { MantineProvider } from "@mantine/core";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { SpellRemoveModal } from "./spell-remove-modal.js";
+
+describe("SpellRemoveModal", () => {
+	it("renders confirmation copy for the selected spell", () => {
+		const html = renderToString(
+			<MantineProvider>
+				<SpellRemoveModal
+					onClose={vi.fn()}
+					onConfirm={vi.fn()}
+					pending={false}
+					withinPortal={false}
+					spell={{
+						id: "00000000-0000-4000-8000-000000000030",
+						slotLevel: 3,
+						spellIndex: "magic-missile",
+						name: "Magic Missile",
+						level: 1,
+						url: "/api/2014/spells/magic-missile",
+						source: "spell",
+					}}
+				/>
+			</MantineProvider>,
+		);
+
+		const readableHtml = html.replaceAll("<!-- -->", "");
+		expect(readableHtml).toContain("Remove Magic Missile?");
+		expect(readableHtml).toContain("This removes the spell from this character");
+		expect(readableHtml).toContain("Cancel");
+		expect(readableHtml).toContain("Remove spell");
+	});
+});

--- a/src/domains/characters/ui/spell-remove-modal.tsx
+++ b/src/domains/characters/ui/spell-remove-modal.tsx
@@ -1,0 +1,40 @@
+import { Button, Group, Modal, Stack, Text } from "@mantine/core";
+import type { CharacterSpellsResponse } from "../../../generated/api-client.generated.js";
+
+interface SpellRemoveModalProps {
+	onClose: () => void;
+	onConfirm: () => void;
+	pending: boolean;
+	spell: CharacterSpellsResponse["spells"][number] | null;
+	withinPortal?: boolean;
+}
+
+export function SpellRemoveModal({
+	onClose,
+	onConfirm,
+	pending,
+	spell,
+	withinPortal = true,
+}: SpellRemoveModalProps) {
+	return (
+		<Modal
+			centered
+			onClose={onClose}
+			opened={spell !== null}
+			title={spell ? `Remove ${spell.name}?` : "Remove spell?"}
+			withinPortal={withinPortal}
+		>
+			<Stack gap="md">
+				<Text size="sm">This removes the spell from this character&apos;s spell list.</Text>
+				<Group justify="flex-end" gap="xs">
+					<Button color="gray" disabled={pending} onClick={onClose} variant="default">
+						Cancel
+					</Button>
+					<Button color="red" loading={pending} onClick={onConfirm}>
+						Remove spell
+					</Button>
+				</Group>
+			</Stack>
+		</Modal>
+	);
+}

--- a/src/domains/characters/ui/spell-slot-history.test.tsx
+++ b/src/domains/characters/ui/spell-slot-history.test.tsx
@@ -1,0 +1,50 @@
+import { MantineProvider } from "@mantine/core";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { SpellSlotHistory } from "./spell-slot-history.js";
+
+describe("SpellSlotHistory", () => {
+	it("renders recent spell slot changes only when opened", () => {
+		const closedHtml = renderToString(
+			<MantineProvider>
+				<SpellSlotHistory
+					changes={[
+						{
+							id: "00000000-0000-4000-8000-000000000040",
+							action: "used",
+							level: 1,
+							previous: { total: 2, used: 0, remaining: 2 },
+							next: { total: 2, used: 1, remaining: 1 },
+							totalDelta: 0,
+							usedDelta: 1,
+							createdAt: "2026-07-01T12:00:00.000Z",
+						},
+					]}
+					opened={false}
+				/>
+			</MantineProvider>,
+		);
+		const openedHtml = renderToString(
+			<MantineProvider>
+				<SpellSlotHistory
+					changes={[
+						{
+							id: "00000000-0000-4000-8000-000000000040",
+							action: "used",
+							level: 1,
+							previous: { total: 2, used: 0, remaining: 2 },
+							next: { total: 2, used: 1, remaining: 1 },
+							totalDelta: 0,
+							usedDelta: 1,
+							createdAt: "2026-07-01T12:00:00.000Z",
+						},
+					]}
+					opened={true}
+				/>
+			</MantineProvider>,
+		);
+
+		expect(closedHtml).not.toContain("Used 1st-level slot");
+		expect(openedHtml).toContain("Used 1st-level slot");
+	});
+});

--- a/src/domains/characters/ui/spell-slot-history.tsx
+++ b/src/domains/characters/ui/spell-slot-history.tsx
@@ -1,0 +1,31 @@
+import { Group, Stack, Text } from "@mantine/core";
+import type { CharacterSpellSlotsResponse } from "../../../generated/api-client.generated.js";
+import { formatSpellSlotChange } from "./spell-slot-format.js";
+
+interface SpellSlotHistoryProps {
+	changes: CharacterSpellSlotsResponse["recentSpellSlotChanges"];
+	opened: boolean;
+}
+
+export function SpellSlotHistory({ changes, opened }: SpellSlotHistoryProps) {
+	if (!opened) return null;
+
+	return (
+		<Stack gap="xs">
+			{changes.length ? (
+				changes.map((change) => (
+					<Group key={change.id} justify="space-between">
+						<Text size="sm">{formatSpellSlotChange(change)}</Text>
+						<Text c="dimmed" size="xs">
+							{new Date(change.createdAt).toLocaleString()}
+						</Text>
+					</Group>
+				))
+			) : (
+				<Text c="dimmed" size="sm">
+					No spell slot changes yet.
+				</Text>
+			)}
+		</Stack>
+	);
+}

--- a/src/domains/characters/ui/spell-slot-list.test.tsx
+++ b/src/domains/characters/ui/spell-slot-list.test.tsx
@@ -24,6 +24,7 @@ describe("SpellSlotList", () => {
 					onDraftTotalChange={vi.fn()}
 					onOpenSpellDetails={vi.fn()}
 					onOpenSpellSearch={vi.fn()}
+					onRemoveSpell={vi.fn()}
 					onRestoreSlot={vi.fn()}
 					onUseSlot={vi.fn()}
 					spellSlots={[
@@ -55,6 +56,7 @@ describe("SpellSlotList", () => {
 					onDraftTotalChange={vi.fn()}
 					onOpenSpellDetails={vi.fn()}
 					onOpenSpellSearch={vi.fn()}
+					onRemoveSpell={vi.fn()}
 					onRestoreSlot={vi.fn()}
 					onUseSlot={vi.fn()}
 					spellSlots={[
@@ -91,6 +93,7 @@ describe("SpellSlotList", () => {
 					onDraftTotalChange={vi.fn()}
 					onOpenSpellDetails={vi.fn()}
 					onOpenSpellSearch={vi.fn()}
+					onRemoveSpell={vi.fn()}
 					onRestoreSlot={vi.fn()}
 					onUseSlot={vi.fn()}
 					spellSlots={[
@@ -106,5 +109,52 @@ describe("SpellSlotList", () => {
 		expect(html).not.toContain('aria-label="Add spell to 5th-level"');
 		expect(readableHtml).toContain("Divine Smite");
 		expect(readableHtml).toContain("2nd-level feature");
+	});
+
+	it("shows saved spell remove controls only while editing", () => {
+		const spell = {
+			id: "00000000-0000-4000-8000-000000000030",
+			slotLevel: 3,
+			spellIndex: "magic-missile",
+			name: "Magic Missile",
+			level: 1,
+			url: "/api/2014/spells/magic-missile",
+			source: "spell" as const,
+		};
+		const viewHtml = renderToString(
+			<MantineProvider>
+				<SpellSlotList
+					characterSpells={[spell]}
+					draftTotals={{}}
+					isEditing={false}
+					onDraftTotalChange={vi.fn()}
+					onOpenSpellDetails={vi.fn()}
+					onOpenSpellSearch={vi.fn()}
+					onRemoveSpell={vi.fn()}
+					onRestoreSlot={vi.fn()}
+					onUseSlot={vi.fn()}
+					spellSlots={[{ level: 3, total: 2, used: 0, remaining: 2 }]}
+				/>
+			</MantineProvider>,
+		);
+		const editHtml = renderToString(
+			<MantineProvider>
+				<SpellSlotList
+					characterSpells={[spell]}
+					draftTotals={{}}
+					isEditing={true}
+					onDraftTotalChange={vi.fn()}
+					onOpenSpellDetails={vi.fn()}
+					onOpenSpellSearch={vi.fn()}
+					onRemoveSpell={vi.fn()}
+					onRestoreSlot={vi.fn()}
+					onUseSlot={vi.fn()}
+					spellSlots={[{ level: 3, total: 2, used: 0, remaining: 2 }]}
+				/>
+			</MantineProvider>,
+		);
+
+		expect(viewHtml).not.toContain('aria-label="Remove Magic Missile"');
+		expect(editHtml).toContain('aria-label="Remove Magic Missile"');
 	});
 });

--- a/src/domains/characters/ui/spell-slot-list.tsx
+++ b/src/domains/characters/ui/spell-slot-list.tsx
@@ -11,6 +11,7 @@ interface SpellSlotListProps {
 	onDraftTotalChange: (slotLevel: number, value: NumberDraft) => void;
 	onOpenSpellDetails: (spell: CharacterSpellsResponse["spells"][number]) => void;
 	onOpenSpellSearch: (slotLevel: number) => void;
+	onRemoveSpell: (spell: CharacterSpellsResponse["spells"][number]) => void;
 	onRestoreSlot: (slot: CharacterSpellSlot) => void;
 	onUseSlot: (slot: CharacterSpellSlot) => void;
 	spellSlots: CharacterSpellSlot[];
@@ -23,6 +24,7 @@ export function SpellSlotList({
 	onDraftTotalChange,
 	onOpenSpellDetails,
 	onOpenSpellSearch,
+	onRemoveSpell,
 	onRestoreSlot,
 	onUseSlot,
 	spellSlots,
@@ -103,20 +105,33 @@ export function SpellSlotList({
 							<Stack gap={2}>
 								{savedSpells.map((spell) => (
 									<Group key={spell.id} justify="space-between" gap="xs" wrap="nowrap">
-										<Anchor
-											aria-label={`View ${spell.name} details`}
-											component="button"
-											onClick={() => onOpenSpellDetails(spell)}
-											size="sm"
-											ta="left"
-											type="button"
-										>
-											{spell.name}
-										</Anchor>
-										<Text c="dimmed" size="xs">
-											{formatSpellLevel(spell.level)}{" "}
-											{spell.source === "feature" ? "feature" : "spell"}
-										</Text>
+										<Stack gap={0} style={{ flex: "1 1 auto", minWidth: 0 }}>
+											<Anchor
+												aria-label={`View ${spell.name} details`}
+												component="button"
+												onClick={() => onOpenSpellDetails(spell)}
+												size="sm"
+												ta="left"
+												type="button"
+											>
+												{spell.name}
+											</Anchor>
+											<Text c="dimmed" size="xs">
+												{formatSpellLevel(spell.level)}{" "}
+												{spell.source === "feature" ? "feature" : "spell"}
+											</Text>
+										</Stack>
+										{isEditing && (
+											<Button
+												aria-label={`Remove ${spell.name}`}
+												color="red"
+												onClick={() => onRemoveSpell(spell)}
+												size="compact-xs"
+												variant="subtle"
+											>
+												Remove
+											</Button>
+										)}
 									</Group>
 								))}
 							</Stack>

--- a/src/domains/characters/ui/spell-slot-panel.tsx
+++ b/src/domains/characters/ui/spell-slot-panel.tsx
@@ -15,8 +15,9 @@ import {
 import type { CharacterSpellSlot } from "../types/index.js";
 import type { NumberDraft } from "./health-dialogs.js";
 import { SpellDetailsModal } from "./spell-details-modal.js";
+import { SpellRemoveModal } from "./spell-remove-modal.js";
 import { SpellSearchModal, type SpellSearchResult } from "./spell-search-modal.js";
-import { formatSpellSlotChange } from "./spell-slot-format.js";
+import { SpellSlotHistory } from "./spell-slot-history.js";
 import { SpellSlotList } from "./spell-slot-list.js";
 
 interface SpellSearchState {
@@ -38,6 +39,9 @@ export function CharacterSpellSlotsPanel({
 	const [isEditing, setIsEditing] = useState(false);
 	const [spellSearch, setSpellSearch] = useState<SpellSearchState | null>(null);
 	const [selectedSpellId, setSelectedSpellId] = useState<string | null>(null);
+	const [spellToRemove, setSpellToRemove] = useState<
+		CharacterSpellsResponse["spells"][number] | null
+	>(null);
 	const queryClient = useQueryClient();
 	const spellSlots = spellSlotsQuery.data?.spellSlots ?? [];
 	const characterSpells = characterSpellsQuery.data?.spells ?? [];
@@ -70,7 +74,6 @@ export function CharacterSpellSlotsPanel({
 
 	function updateCachedCharacterSpells(response: CharacterSpellsResponse) {
 		queryClient.setQueryData(apiQueryKeys.listCharacterSpells({ characterId }), response);
-		closeSpellSearch();
 	}
 
 	const updateMutation = useMutation({
@@ -91,7 +94,17 @@ export function CharacterSpellSlotsPanel({
 	});
 	const saveSpellMutation = useMutation({
 		...apiMutations.saveCharacterSpell(),
-		onSuccess: updateCachedCharacterSpells,
+		onSuccess: (response) => {
+			updateCachedCharacterSpells(response);
+			closeSpellSearch();
+		},
+	});
+	const removeSpellMutation = useMutation({
+		...apiMutations.removeCharacterSpell(),
+		onSuccess: (response) => {
+			updateCachedCharacterSpells(response);
+			setSpellToRemove(null);
+		},
 	});
 
 	function setDraftTotal(slotLevel: number, value: NumberDraft) {
@@ -137,8 +150,8 @@ export function CharacterSpellSlotsPanel({
 		setSpellSearch(null);
 	}
 
-	function closeSpellDetails() {
-		setSelectedSpellId(null);
+	function closeRemoveSpellDialog() {
+		if (!removeSpellMutation.isPending) setSpellToRemove(null);
 	}
 
 	function updateSpellSearchQuery(query: string) {
@@ -151,6 +164,11 @@ export function CharacterSpellSlotsPanel({
 			params: { characterId },
 			body: { slotLevel: spellSearch.slotLevel, spellIndex: spell.index, source: spell.source },
 		});
+	}
+
+	function removeSpell() {
+		if (!spellToRemove) return;
+		removeSpellMutation.mutate({ characterId, spellId: spellToRemove.id });
 	}
 
 	return (
@@ -186,24 +204,10 @@ export function CharacterSpellSlotsPanel({
 
 			{spellSlotsQuery.isLoading && <Text c="dimmed">Loading spell slots...</Text>}
 
-			{historyOpen && (
-				<Stack gap="xs">
-					{spellSlotsQuery.data?.recentSpellSlotChanges.length ? (
-						spellSlotsQuery.data.recentSpellSlotChanges.map((change) => (
-							<Group key={change.id} justify="space-between">
-								<Text size="sm">{formatSpellSlotChange(change)}</Text>
-								<Text c="dimmed" size="xs">
-									{new Date(change.createdAt).toLocaleString()}
-								</Text>
-							</Group>
-						))
-					) : (
-						<Text c="dimmed" size="sm">
-							No spell slot changes yet.
-						</Text>
-					)}
-				</Stack>
-			)}
+			<SpellSlotHistory
+				changes={spellSlotsQuery.data?.recentSpellSlotChanges ?? []}
+				opened={historyOpen}
+			/>
 
 			{isEditing && (
 				<Group gap="xs" wrap="wrap">
@@ -237,6 +241,7 @@ export function CharacterSpellSlotsPanel({
 				onDraftTotalChange={setDraftTotal}
 				onOpenSpellDetails={(spell) => setSelectedSpellId(spell.id)}
 				onOpenSpellSearch={openSpellSearch}
+				onRemoveSpell={setSpellToRemove}
 				onRestoreSlot={restoreSlot}
 				onUseSlot={expendSlot}
 				spellSlots={spellSlots}
@@ -254,6 +259,7 @@ export function CharacterSpellSlotsPanel({
 			{(characterSpellsQuery.error ||
 				spellSearchQuery.error ||
 				spellDetailsQuery.error ||
+				removeSpellMutation.error ||
 				saveSpellMutation.error) && (
 				<Alert color="red" title="Spells unavailable" variant="light">
 					Try the spell change again.
@@ -273,9 +279,15 @@ export function CharacterSpellSlotsPanel({
 			/>
 			<SpellDetailsModal
 				details={spellDetailsQuery.data?.spell ?? null}
-				onClose={closeSpellDetails}
+				onClose={() => setSelectedSpellId(null)}
 				opened={selectedSpellId !== null}
 				pending={spellDetailsQuery.isFetching}
+			/>
+			<SpellRemoveModal
+				onClose={closeRemoveSpellDialog}
+				onConfirm={removeSpell}
+				pending={removeSpellMutation.isPending}
+				spell={spellToRemove}
 			/>
 		</Stack>
 	);

--- a/src/generated/api-client.generated.ts
+++ b/src/generated/api-client.generated.ts
@@ -90,6 +90,10 @@ export function createApiClient(options: ApiClientOptions = {}) {
 
 		saveCharacterSpell(params: { characterId: string }, body: SaveCharacterSpellRequest, options: ApiRequestOptions = {}): Promise<CharacterSpellsResponse> {
 			return request<CharacterSpellsResponse>(fetchImpl, baseUrl, "POST", `/api/characters/${params.characterId}/spells`, options, body, (body: unknown) => CharacterSpellsResponseSchema.parse(body));
+		},
+
+		removeCharacterSpell(params: { characterId: string; spellId: string }, options: ApiRequestOptions = {}): Promise<CharacterSpellsResponse> {
+			return request<CharacterSpellsResponse>(fetchImpl, baseUrl, "DELETE", `/api/characters/${params.characterId}/spells/${params.spellId}`, options, undefined, (body: unknown) => CharacterSpellsResponseSchema.parse(body));
 		}
 	};
 }
@@ -181,6 +185,11 @@ export function createApiMutationOptions(client = apiClient) {
 		saveCharacterSpell: (options: ApiRequestOptions = {}) => mutationOptions({
 			mutationKey: ["api", "saveCharacterSpell"] as const,
 			mutationFn: (variables: { params: { characterId: string }; body: SaveCharacterSpellRequest }) => client.saveCharacterSpell(variables.params, variables.body, options),
+		}),
+
+		removeCharacterSpell: (options: ApiRequestOptions = {}) => mutationOptions({
+			mutationKey: ["api", "removeCharacterSpell"] as const,
+			mutationFn: (params: { characterId: string; spellId: string }) => client.removeCharacterSpell(params, options),
 		}),
 	};
 }

--- a/src/generated/openapi.generated.json
+++ b/src/generated/openapi.generated.json
@@ -2563,6 +2563,131 @@
 						}
 					}
 				}
+			},
+			"delete": {
+				"operationId": "removeCharacterSpell",
+				"summary": "Remove character spell",
+				"tags": [
+					"characters"
+				],
+				"parameters": [
+					{
+						"name": "characterId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"format": "uuid",
+							"pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+						}
+					},
+					{
+						"name": "spellId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"format": "uuid",
+							"pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Updated saved character spells",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"spells": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"id": {
+														"type": "string",
+														"format": "uuid",
+														"pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+													},
+													"slotLevel": {
+														"type": "integer",
+														"minimum": 1,
+														"maximum": 9
+													},
+													"spellIndex": {
+														"type": "string",
+														"minLength": 1,
+														"maxLength": 120,
+														"pattern": "^[a-z0-9-]+$"
+													},
+													"name": {
+														"type": "string",
+														"minLength": 1,
+														"maxLength": 120,
+														"pattern": "\\S"
+													},
+													"level": {
+														"type": "integer",
+														"minimum": 1,
+														"maximum": 20
+													},
+													"url": {
+														"type": "string",
+														"minLength": 1,
+														"maxLength": 240,
+														"pattern": "^\\/api\\/2014\\/(?:features|spells)\\/[a-z0-9-]+$"
+													},
+													"source": {
+														"default": "spell",
+														"type": "string",
+														"enum": [
+															"spell",
+															"feature"
+														]
+													}
+												},
+												"required": [
+													"id",
+													"slotLevel",
+													"spellIndex",
+													"name",
+													"level",
+													"url",
+													"source"
+												],
+												"additionalProperties": false
+											}
+										}
+									},
+									"required": [
+										"spells"
+									],
+									"additionalProperties": false
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Character not found",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"error"
+									],
+									"additionalProperties": false
+								}
+							}
+						}
+					}
+				}
 			}
 		},
 		"/api/characters/{characterId}/spells/search": {

--- a/tests/e2e/character-health-flow.spec.ts
+++ b/tests/e2e/character-health-flow.spec.ts
@@ -105,6 +105,9 @@ test("configures spell slots and tracks spell usage on detail", async ({ page })
 	await expect(page.getByRole("dialog", { name: "Add spell to 3rd-level" })).toBeHidden();
 	await expect(page.getByRole("button", { name: "View Divine Smite details" })).toBeVisible();
 	await expect(page.getByText("2nd-level feature")).toBeVisible();
+	await expect(page.getByRole("button", { name: "Remove Divine Smite" })).toBeVisible();
+	await page.getByRole("button", { name: "Done" }).click();
+	await expect(page.getByRole("button", { name: "Remove Divine Smite" })).toBeHidden();
 	await page.getByRole("button", { name: "Add spell to 3rd-level" }).click();
 	addSpellDialog = page.getByRole("dialog", { name: "Add spell to 3rd-level" });
 	await expect(addSpellDialog).toBeVisible();
@@ -126,6 +129,23 @@ test("configures spell slots and tracks spell usage on detail", async ({ page })
 	await expect(page.getByText(/radiant damage/i)).toBeVisible();
 	await page.keyboard.press("Escape");
 	await expect(page.getByRole("dialog", { name: "Divine Smite" })).toBeHidden();
+
+	await page.getByRole("button", { name: "Edit spells" }).click();
+	await page.getByRole("button", { name: "Remove Divine Smite" }).click();
+	await expect(page.getByRole("dialog", { name: "Remove Divine Smite?" })).toBeVisible();
+	await page.getByRole("button", { name: "Cancel" }).click();
+	await expect(page.getByRole("button", { name: "View Divine Smite details" })).toBeVisible();
+	await page.getByRole("button", { name: "Remove Divine Smite" }).click();
+	await page.getByRole("button", { name: "Remove spell" }).click();
+	await expect(page.getByRole("button", { name: "View Divine Smite details" })).toBeHidden();
+	await expect(page.getByText("2nd-level feature")).toBeHidden();
+	await page.getByRole("button", { name: "Add spell to 3rd-level" }).click();
+	addSpellDialog = page.getByRole("dialog", { name: "Add spell to 3rd-level" });
+	await page.getByLabel("Search spells").fill("divine smite");
+	await page.getByRole("button", { name: /^Divine Smite\b/ }).click();
+	await expect(addSpellDialog).toBeHidden();
+	await page.getByRole("button", { name: "Done" }).click();
+	await expect(page.getByRole("button", { name: "Remove Divine Smite" })).toBeHidden();
 
 	await page.getByRole("button", { name: "Use 1st-level" }).click();
 	await expect(page.getByText("1 / 2 remaining")).toBeVisible();


### PR DESCRIPTION
## Summary

Adds the ability to remove saved spells from a character's spell list.

- Adds a typed `DELETE /api/characters/:characterId/spells/:spellId` route that returns the updated saved spell list.
- Wires removal through the character spell repository and service with ownership checks.
- Adds an edit-mode remove control with a confirmation dialog and cache update in the spell-slot panel.
- Regenerates the OpenAPI document and typed frontend client.
- Expands unit, integration, route, and e2e coverage for the remove-spell flow.

## Validation

- `pnpm lint`
- `pnpm api:check`
- `pnpm build`
- `pnpm test`
- `pnpm check:docs`
- Manual browser smoke on local stack: created a Wizard, configured spell slots, added Divine Smite, removed it through the confirmation dialog, reloaded, and verified the spell stayed removed.