### PR TITLE
Add spell slot progress bars

### DIFF
--- a/src/domains/characters/ui/spell-slot-list.test.tsx
+++ b/src/domains/characters/ui/spell-slot-list.test.tsx
@@ -56,6 +56,85 @@ describe("SpellSlotList", () => {
 		expect(readableHtml).toContain("Total 2");
 	});
 
+	it("renders a compact usage bar for each visible spell slot level", () => {
+		const html = renderToString(
+			<MantineProvider>
+				<SpellSlotList
+					characterSpells={[]}
+					draftTotals={{}}
+					isEditing={false}
+					onDraftTotalChange={vi.fn()}
+					onOpenSpellDetails={vi.fn()}
+					onOpenSpellSearch={vi.fn()}
+					onRemoveSpell={vi.fn()}
+					onRestoreSlot={vi.fn()}
+					onUseSlot={vi.fn()}
+					spellSlots={[
+						{ level: 3, total: 4, used: 1, remaining: 3 },
+						{ level: 4, total: 1, used: 1, remaining: 0 },
+					]}
+				/>
+			</MantineProvider>,
+		);
+
+		expect(html).toContain('aria-label="3rd-level spell slots: 3 of 4 remaining"');
+		expect(html).toContain('aria-valuenow="75"');
+		expect(html).toContain('aria-label="4th-level spell slots: 0 of 1 remaining"');
+		expect(html).toContain('aria-valuenow="0"');
+	});
+
+	it("renders the last remaining spell slot in red even when the bar is not empty", () => {
+		const html = renderToString(
+			<MantineProvider>
+				<SpellSlotList
+					characterSpells={[]}
+					draftTotals={{}}
+					isEditing={false}
+					onDraftTotalChange={vi.fn()}
+					onOpenSpellDetails={vi.fn()}
+					onOpenSpellSearch={vi.fn()}
+					onRemoveSpell={vi.fn()}
+					onRestoreSlot={vi.fn()}
+					onUseSlot={vi.fn()}
+					spellSlots={[
+						{ level: 3, total: 3, used: 2, remaining: 1 },
+						{ level: 4, total: 4, used: 3, remaining: 1 },
+					]}
+				/>
+			</MantineProvider>,
+		);
+
+		expect(html).toContain('aria-label="3rd-level spell slots: 1 of 3 remaining"');
+		expect(html).toContain('aria-label="4th-level spell slots: 1 of 4 remaining"');
+		expect(
+			html.match(/--progress-section-color:var\(--mantine-color-red-filled\)/g) ?? [],
+		).toHaveLength(2);
+		expect(html).not.toContain("--progress-section-color:var(--mantine-color-yellow-filled)");
+	});
+
+	it("keeps a one-of-one spell slot in the healthy color", () => {
+		const html = renderToString(
+			<MantineProvider>
+				<SpellSlotList
+					characterSpells={[]}
+					draftTotals={{}}
+					isEditing={false}
+					onDraftTotalChange={vi.fn()}
+					onOpenSpellDetails={vi.fn()}
+					onOpenSpellSearch={vi.fn()}
+					onRemoveSpell={vi.fn()}
+					onRestoreSlot={vi.fn()}
+					onUseSlot={vi.fn()}
+					spellSlots={[{ level: 5, total: 1, used: 0, remaining: 1 }]}
+				/>
+			</MantineProvider>,
+		);
+
+		expect(html).toContain('aria-label="5th-level spell slots: 1 of 1 remaining"');
+		expect(html).toContain("--progress-section-color:var(--mantine-color-green-filled)");
+		expect(html).not.toContain("--progress-section-color:var(--mantine-color-red-filled)");
+	});
+
 	it("shows all slot levels while editing", () => {
 		const html = renderToString(
 			<MantineProvider>

--- a/src/domains/characters/ui/spell-slot-list.tsx
+++ b/src/domains/characters/ui/spell-slot-list.tsx
@@ -1,4 +1,4 @@
-import { Anchor, Button, Group, NumberInput, Stack, Text } from "@mantine/core";
+import { Anchor, Button, Group, NumberInput, Progress, Stack, Text } from "@mantine/core";
 import type { CharacterSpellsResponse } from "../../../generated/api-client.generated.js";
 import type { CharacterSpellSlot } from "../types/index.js";
 import type { NumberDraft } from "./health-dialogs.js";
@@ -63,6 +63,13 @@ export function SpellSlotList({
 								<Text c="dimmed" size="xs">
 									{slot.remaining} / {slot.total} remaining
 								</Text>
+								<Progress
+									aria-label={`${formatSpellLevel(slot.level)} spell slots: ${slot.remaining} of ${slot.total} remaining`}
+									color={getSlotUsageColor(slot)}
+									radius="xs"
+									size="xs"
+									value={getSlotUsagePercent(slot)}
+								/>
 							</Stack>
 							{isEditing ? (
 								<NumberInput
@@ -144,4 +151,16 @@ export function SpellSlotList({
 
 function toDraft(value: number | string): NumberDraft {
 	return typeof value === "number" && Number.isFinite(value) ? value : "";
+}
+
+function getSlotUsagePercent(slot: CharacterSpellSlot) {
+	if (slot.total <= 0) return 0;
+	return Math.round((slot.remaining / slot.total) * 100);
+}
+
+function getSlotUsageColor(slot: CharacterSpellSlot) {
+	const usagePercent = getSlotUsagePercent(slot);
+	if (slot.remaining <= 0 || (slot.total > 1 && slot.remaining === 1)) return "red";
+	if (usagePercent <= 50) return "yellow";
+	return "green";
 }

--- a/tests/e2e/character-health-flow.spec.ts
+++ b/tests/e2e/character-health-flow.spec.ts
@@ -78,7 +78,9 @@ test("configures spell slots and tracks spell usage on detail", async ({ page })
 		timeout: spellApiTimeoutMs,
 	});
 	await page.getByRole("button", { name: /^Light\b/ }).click();
-	await expect(page.getByRole("dialog", { name: "Add cantrip or feature" })).toBeHidden();
+	await expect(page.getByRole("dialog", { name: "Add cantrip or feature" })).toBeHidden({
+		timeout: spellApiTimeoutMs,
+	});
 	await expect(page.getByRole("button", { name: "View Light details" })).toBeVisible();
 	await expect(page.getByText("Cantrip", { exact: true })).toBeVisible();
 	await page.getByRole("button", { name: "Add cantrip or feature" }).click();
@@ -102,6 +104,9 @@ test("configures spell slots and tracks spell usage on detail", async ({ page })
 	await page.getByLabel("1st-level slot total").fill("2");
 	await page.getByRole("button", { name: "Apply changes" }).click();
 	await expect(page.getByText("2 / 2 remaining")).toBeVisible();
+	await expect(
+		page.getByRole("progressbar", { name: "1st-level spell slots: 2 of 2 remaining" }),
+	).toHaveAttribute("aria-valuenow", "100");
 	await expect(page.getByRole("button", { name: "Add spell to 3rd-level" })).toBeHidden();
 	await page.getByRole("button", { name: /Spell history/ }).click();
 	await expect(page.getByText("Configured 1st-level: 2 slots")).toBeVisible();
@@ -185,12 +190,18 @@ test("configures spell slots and tracks spell usage on detail", async ({ page })
 
 	await page.getByRole("button", { name: "Use 1st-level" }).click();
 	await expect(page.getByText("1 / 2 remaining")).toBeVisible();
+	await expect(
+		page.getByRole("progressbar", { name: "1st-level spell slots: 1 of 2 remaining" }),
+	).toHaveAttribute("aria-valuenow", "50");
 
 	await page.getByRole("button", { name: /Spell history/ }).click();
 	await expect(page.getByText("Used 1st-level slot")).toBeVisible();
 
 	await page.getByRole("button", { name: "Restore 1st-level" }).click();
 	await expect(page.getByText("2 / 2 remaining")).toBeVisible();
+	await expect(
+		page.getByRole("progressbar", { name: "1st-level spell slots: 2 of 2 remaining" }),
+	).toHaveAttribute("aria-valuenow", "100");
 	await expect(page.getByText("Restored 1st-level slot")).toBeVisible();
 
 	await page.reload();


### PR DESCRIPTION
## Summary

- Add compact per-level progress bars for spell slot remaining counts
- Color low spell-slot pools red when only one slot remains from a larger pool, while keeping one-of-one slots green
- Add unit and e2e coverage for full, partial, empty, and restored slot bar states

## Validation

- pnpm lint
- pnpm test:unit
- pnpm build
- pnpm test